### PR TITLE
Polished API based on initial user feedback

### DIFF
--- a/compiler/examples/USMap/USMap.js
+++ b/compiler/examples/USMap/USMap.js
@@ -56,7 +56,7 @@ var selector = function (row, args) {
 };
 
 var newPredicates = function () {
-    return ["", "", ""];
+    return [{}, {}, {}];
 };
 
 var newViewport = function (row) {
@@ -71,7 +71,7 @@ p.addJump(new Jump(stateMapCanvas, countyMapCanvas, "geometric_semantic_zoom", {
     viewport : newViewport, predicates : newPredicates, name : jumpName}));
 
 // setting initial states
-p.setInitialStates(stateMapCanvas, 0, 0, ["", ""]);
+p.setInitialStates(stateMapCanvas, 0, 0);
 
 // save to db
 p.saveProject();

--- a/compiler/examples/USMap/USMap.js
+++ b/compiler/examples/USMap/USMap.js
@@ -51,8 +51,8 @@ countyBoundaryLayer.addPlacement(placements.countyMapPlacement);
 countyBoundaryLayer.addRenderingFunc(renderers.countyMapRendering);
 
 // ================== state -> county ===================
-var selector = function (row, layerId) {
-    return (layerId == 1);
+var selector = function (row, args) {
+    return (args.layerId == 1);
 };
 
 var newPredicates = function () {

--- a/compiler/examples/USMap/USMap.js
+++ b/compiler/examples/USMap/USMap.js
@@ -56,7 +56,7 @@ var selector = function (row, args) {
 };
 
 var newPredicates = function () {
-    return [{}, {}, {}];
+    return {};
 };
 
 var newViewport = function (row) {

--- a/compiler/examples/USMap/USMap.js
+++ b/compiler/examples/USMap/USMap.js
@@ -60,7 +60,7 @@ var newPredicates = function () {
 };
 
 var newViewport = function (row) {
-    return [0, row.bbox_x * 5 - 1000, row.bbox_y * 5 - 500];
+    return {"constant" : [row.bbox_x * 5 - 1000, row.bbox_y * 5 - 500]};
 };
 
 var jumpName = function (row) {

--- a/compiler/examples/USMap/USMap.js
+++ b/compiler/examples/USMap/USMap.js
@@ -60,11 +60,11 @@ var newPredicates = function () {
 };
 
 var newViewport = function (row) {
-    return [0, row[1] * 5 - 1000, row[2] * 5 - 500];
+    return [0, row.bbox_x * 5 - 1000, row.bbox_y * 5 - 500];
 };
 
 var jumpName = function (row) {
-    return "County map of " + row[3];
+    return "County map of " + row.name;
 };
 
 p.addJump(new Jump(stateMapCanvas, countyMapCanvas, "geometric_semantic_zoom", {selector : selector,

--- a/compiler/examples/USMap/USMap.js
+++ b/compiler/examples/USMap/USMap.js
@@ -67,7 +67,8 @@ var jumpName = function (row) {
     return "County map of " + row[3];
 };
 
-p.addJump(new Jump(stateMapCanvas, countyMapCanvas, selector, newViewport, newPredicates, "geometric_semantic_zoom", jumpName));
+p.addJump(new Jump(stateMapCanvas, countyMapCanvas, "geometric_semantic_zoom", {selector : selector,
+    viewport : newViewport, predicates : newPredicates, name : jumpName}));
 
 // setting initial states
 p.setInitialStates(stateMapCanvas, 0, 0, ["", ""]);

--- a/compiler/examples/USMap/renderers.js
+++ b/compiler/examples/USMap/renderers.js
@@ -28,13 +28,13 @@ var stateMapRendering = function (svg, data, args) {
         .enter()
         .append("path")
         .attr("d", function (d) {
-            var feature = JSON.parse(d[5]);
+            var feature = JSON.parse(d.geomstr);
             return path(feature);
         })
         .style("stroke", "#fff")
         .style("stroke-width", "0.5")
         .style("fill", function (d) {
-            return color(d[4]);
+            return color(d.crimerate);
         });
 };
 
@@ -113,7 +113,7 @@ var countyMapStateBoundaryRendering = function (svg, data, args) {
         .enter()
         .append("path")
         .attr("d", function (d) {
-            var feature = JSON.parse(d[4]);
+            var feature = JSON.parse(d.geomstr);
             return path(feature);
         })
         .style("stroke", "#fff")
@@ -212,13 +212,13 @@ var countyMapRendering = function (svg, data, args) {
         .enter()
         .append("path")
         .attr("d", function (d) {
-            var feature = JSON.parse(d[9]);
+            var feature = JSON.parse(d.geomstr);
             return path(feature);
         })
         .style("stroke", "#fff")
         .style("stroke-width", "0.5")
         .style("fill", function (d) {
-            return color(d[7]);
+            return color(d.crimerate);
         })
         .on("mouseover", function (d, i) {
 
@@ -240,7 +240,7 @@ var countyMapRendering = function (svg, data, args) {
             tooltip.transition()
                 .duration(200)
                 .style("opacity", .9);
-            tooltip.html(d[6] + "\n" + d[7])
+            tooltip.html(d.name + "\n" + d.crimerate)
                 .style("left", (d3.event.pageX) + "px")
                 .style("top", (d3.event.pageY) + "px");
         })

--- a/compiler/examples/USMap/renderers.js
+++ b/compiler/examples/USMap/renderers.js
@@ -52,7 +52,7 @@ var stateMapLegendRendering = function (svg, data, args) {
     var tickFontSize = 12;
 
     var g = svg.append("g");
-    var width = args.canvasW;
+    var width = args.viewportW;
     var param = args.renderingParams;
 
     // rectangles representing colors
@@ -136,7 +136,7 @@ var countyMapLegendRendering = function (svg, data, args) {
     var tickFontSize = 12;
 
     var g = svg.append("g");
-    var width = args.canvasW;
+    var width = args.viewportW;
     var param = args.renderingParams;
 
     // append a background rectangle

--- a/compiler/examples/USMap/renderers.js
+++ b/compiler/examples/USMap/renderers.js
@@ -7,9 +7,11 @@ var renderingParams = {
     "countyScaleStep" : 250
 };
 
-var stateMapRendering = function (svg, data, width, height, param) {
+var stateMapRendering = function (svg, data, args) {
 
     g = svg.append("g");
+    var width = args.canvasW, height = args.canvasH;
+    var param = args.renderingParams;
 
     var projection = d3.geoAlbersUsa()
         .scale(param.stateMapScale)
@@ -36,7 +38,7 @@ var stateMapRendering = function (svg, data, width, height, param) {
         });
 };
 
-var stateMapLegendRendering = function (svg, data, width, height, param) {
+var stateMapLegendRendering = function (svg, data, args) {
 
     // parameters
     var bkgRectWidth = 600;
@@ -50,6 +52,8 @@ var stateMapLegendRendering = function (svg, data, width, height, param) {
     var tickFontSize = 12;
 
     var g = svg.append("g");
+    var width = args.canvasW;
+    var param = args.renderingParams;
 
     // rectangles representing colors
     var color = d3.scaleThreshold()
@@ -92,9 +96,11 @@ var stateMapLegendRendering = function (svg, data, width, height, param) {
         .remove();
 };
 
-var countyMapStateBoundaryRendering = function (svg, data, width, height, param) {
+var countyMapStateBoundaryRendering = function (svg, data, args) {
 
     g = svg.append("g");
+    var width = args.canvasW, height = args.canvasH;
+    var param = args.renderingParams;
 
     var projection = d3.geoAlbersUsa()
         .scale(param.countyMapScale)
@@ -115,7 +121,7 @@ var countyMapStateBoundaryRendering = function (svg, data, width, height, param)
         .style("fill", "none");
 };
 
-var countyMapLegendRendering = function (svg, data, width, height, param) {
+var countyMapLegendRendering = function (svg, data, args) {
 
     // parameters
     var bkgRectWidth = 570;
@@ -130,6 +136,8 @@ var countyMapLegendRendering = function (svg, data, width, height, param) {
     var tickFontSize = 12;
 
     var g = svg.append("g");
+    var width = args.canvasW;
+    var param = args.renderingParams;
 
     // append a background rectangle
     g.append("rect")
@@ -182,9 +190,11 @@ var countyMapLegendRendering = function (svg, data, width, height, param) {
         .remove();
 };
 
-var countyMapRendering = function (svg, data, width, height, param) {
+var countyMapRendering = function (svg, data, args) {
 
     g = svg.append("g");
+    var width = args.canvasW, height = args.canvasH;
+    var param = args.renderingParams;
 
     var projection = d3.geoAlbersUsa()
         .scale(param.countyMapScale)

--- a/compiler/examples/flare/flare.js
+++ b/compiler/examples/flare/flare.js
@@ -36,7 +36,7 @@ var newPredicate = function (row) {
             {"==" : ["id", row.id]},
             {"==" : ["parent_id", row.id]}
         ]};
-    return [pred];
+    return {"layer0" : pred};
 };
 
 var jumpName = function (row) {
@@ -47,10 +47,12 @@ p.addJump(new Jump(flareCanvas, flareCanvas, "semantic_zoom", {selector : select
     viewport : newViewport, predicates : newPredicate, name : jumpName}));
 
 // initialize canvas
-p.setInitialStates(flareCanvas, 0, 0, [{"OR" : [
-        {"==" : ["id", "1"]},
-        {"==" : ["parent_id", "1"]}
-    ]}]);
+p.setInitialStates(flareCanvas, 0, 0, {"layer0" : {
+        "OR" : [
+            {"==" : ["id", "1"]},
+            {"==" : ["parent_id", "1"]}
+        ]
+    }});
 
 // save to db
 p.saveProject();

--- a/compiler/examples/flare/flare.js
+++ b/compiler/examples/flare/flare.js
@@ -32,11 +32,11 @@ var newViewport = function () {
 };
 
 var newPredicate = function (row) {
-    return ["(id=\'" + row[0] + "\' or " + "parent_id=\'" + row[0] + "\')"];
+    return ["(id=\'" + row.id + "\' or " + "parent_id=\'" + row.id + "\')"];
 };
 
 var jumpName = function (row) {
-    return "Zoom into " + row[1];
+    return "Zoom into " + row.name;
 };
 
 p.addJump(new Jump(flareCanvas, flareCanvas, "semantic_zoom", {selector : selector,

--- a/compiler/examples/flare/flare.js
+++ b/compiler/examples/flare/flare.js
@@ -32,7 +32,11 @@ var newViewport = function () {
 };
 
 var newPredicate = function (row) {
-    return ["(id=\'" + row.id + "\' or " + "parent_id=\'" + row.id + "\')"];
+    var pred = {"OR" : [
+            {"==" : ["id", row.id]},
+            {"==" : ["parent_id", row.id]}
+        ]};
+    return [pred];
 };
 
 var jumpName = function (row) {
@@ -43,7 +47,10 @@ p.addJump(new Jump(flareCanvas, flareCanvas, "semantic_zoom", {selector : select
     viewport : newViewport, predicates : newPredicate, name : jumpName}));
 
 // initialize canvas
-p.setInitialStates(flareCanvas, 0, 0, ["(id = \'1\' or parent_id = \'1\')"]);
+p.setInitialStates(flareCanvas, 0, 0, [{"OR" : [
+        {"==" : ["id", "1"]},
+        {"==" : ["parent_id", "1"]}
+    ]}]);
 
 // save to db
 p.saveProject();

--- a/compiler/examples/flare/flare.js
+++ b/compiler/examples/flare/flare.js
@@ -23,11 +23,11 @@ flareCanvas.addLayer(flarePackLayer);
 flarePackLayer.addRenderingFunc(renderers.flarePackRendering);
 
 // ================== self jump ===================
-var selector = function (row, layerId) {
-    return (layerId == 0);
+var selector = function () {
+    return true;
 };
 
-var newViewport = function (row) {
+var newViewport = function () {
     return [0, 0, 0]
 };
 

--- a/compiler/examples/flare/flare.js
+++ b/compiler/examples/flare/flare.js
@@ -28,7 +28,7 @@ var selector = function () {
 };
 
 var newViewport = function () {
-    return [0, 0, 0]
+    return {"constant" : [0, 0]};
 };
 
 var newPredicate = function (row) {

--- a/compiler/examples/flare/flare.js
+++ b/compiler/examples/flare/flare.js
@@ -39,7 +39,8 @@ var jumpName = function (row) {
     return "Zoom into " + row[1];
 };
 
-p.addJump(new Jump(flareCanvas, flareCanvas, selector, newViewport, newPredicate, "semantic_zoom", jumpName));
+p.addJump(new Jump(flareCanvas, flareCanvas, "semantic_zoom", {selector : selector,
+    viewport : newViewport, predicates : newPredicate, name : jumpName}));
 
 // initialize canvas
 p.setInitialStates(flareCanvas, 0, 0, ["(id = \'1\' or parent_id = \'1\')"]);

--- a/compiler/examples/flare/renderers.js
+++ b/compiler/examples/flare/renderers.js
@@ -42,9 +42,10 @@ var renderingParams = {"textwrap" : function textwrap(text, width) {
     }
 };
 
-var flarePackRendering = function (svg, data, width, height, params) {
+var flarePackRendering = function (svg, data, args) {
 
     var g = svg.append("g");
+    var params = args.renderingParams;
 
     // get root json from data, using d3-stratify
     var table = [];

--- a/compiler/examples/flare/renderers.js
+++ b/compiler/examples/flare/renderers.js
@@ -51,18 +51,11 @@ var flarePackRendering = function (svg, data, args) {
     var table = [];
     for (var i = 0; i < data.length; i ++) {
 
-        table.push({
-            "id": data[i][0],
-            "name": data[i][1],
-            "size": data[i][2],
-            "parent_id": data[i][3],
-            "depth": data[i][4]
-        });
-
+        table.push(data[i]);
         // check if this one is root, if so, set its parent_id to -1
         var root = true;
         for (var j = 0; j < data.length; j ++)
-            if (i != j && data[j][0] == data[i][3])
+            if (i != j && data[j].id == data[i].parent_id)
                 root = false;
         if (root)
             table[i].parent_id = -1;
@@ -92,9 +85,9 @@ var flarePackRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("circle")
-        .attr("r", function (d) {return dict[d[0]].r;})
-        .attr("cx", function (d) {return dict[d[0]].x;})
-        .attr("cy", function (d) {return dict[d[0]].y;})
+        .attr("r", function (d) {return dict[d.id].r;})
+        .attr("cx", function (d) {return dict[d.id].x;})
+        .attr("cy", function (d) {return dict[d.id].y;})
         .style("fill-opacity", .25)
         .attr("fill", "honeydew")
         .attr("stroke", "#ADADAD")
@@ -104,19 +97,19 @@ var flarePackRendering = function (svg, data, args) {
         .enter()
         .append("text")
         .filter(function (d) {
-            return ! dict[d[0]].children;
+            return ! dict[d.id].children;
         })
         .attr("dy", "0.3em")
-        .text(function (d) {return d[1];})
-        .attr("font-size", function (d) {return dict[d[0]].r / 1000 * 300;})
-        .attr("x", function(d) {return dict[d[0]].x;})
-        .attr("y", function(d) {return dict[d[0]].y;})
+        .text(function (d) {return d.name;})
+        .attr("font-size", function (d) {return dict[d.id].r / 1000 * 300;})
+        .attr("x", function(d) {return dict[d.id].x;})
+        .attr("y", function(d) {return dict[d.id].y;})
         .attr("dy", ".35em")
         .attr("text-anchor", "middle")
         .style("fill-opacity", 1)
         .style("fill", "navy")
         .each(function (d) {
-            params.textwrap(d3.select(this), dict[d[0]].r * 1.5);
+            params.textwrap(d3.select(this), dict[d.id].r * 1.5);
         });
 };
 

--- a/compiler/examples/forest/forest.js
+++ b/compiler/examples/forest/forest.js
@@ -71,7 +71,7 @@ p.addJump(new Jump(c2BackgroundCanvas, c3BackgroundCanvas, "literal_zoom_in"));
 p.addJump(new Jump(c3BackgroundCanvas, c2BackgroundCanvas, "literal_zoom_out"));
 
 // initialize canvas
-p.setInitialStates(c1BackgroundCanvas, 0, 0, ["", ""]);
+p.setInitialStates(c1BackgroundCanvas, 0, 0);
 
 // save to db
 p.saveProject();

--- a/compiler/examples/forest/forest.js
+++ b/compiler/examples/forest/forest.js
@@ -63,12 +63,12 @@ c3BackgroundLayer.addPlacement(placements.c3BackgroundPlacement);
 c3BackgroundLayer.addRenderingFunc(renderers.backgroundRendering);
 
 // ================== Canvas 1 <-> Canvas 2 ===================
-p.addJump(new Jump(c1BackgroundCanvas, c2BackgroundCanvas, 0, "", "", "literal_zoom_in"));
-p.addJump(new Jump(c2BackgroundCanvas, c1BackgroundCanvas, 0, "", "", "literal_zoom_out"));
+p.addJump(new Jump(c1BackgroundCanvas, c2BackgroundCanvas, "literal_zoom_in"));
+p.addJump(new Jump(c2BackgroundCanvas, c1BackgroundCanvas, "literal_zoom_out"));
 
 // ================== Canvas 2 <-> Canvas 3 ===================
-p.addJump(new Jump(c2BackgroundCanvas, c3BackgroundCanvas, 0, "", "", "literal_zoom_in"));
-p.addJump(new Jump(c3BackgroundCanvas, c2BackgroundCanvas, 0, "", "", "literal_zoom_out"));
+p.addJump(new Jump(c2BackgroundCanvas, c3BackgroundCanvas, "literal_zoom_in"));
+p.addJump(new Jump(c3BackgroundCanvas, c2BackgroundCanvas, "literal_zoom_out"));
 
 // initialize canvas
 p.setInitialStates(c1BackgroundCanvas, 0, 0, ["", ""]);

--- a/compiler/examples/forest/renderers.js
+++ b/compiler/examples/forest/renderers.js
@@ -25,11 +25,11 @@ var backgroundRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("image")
-        .attr("x", function (d) {return d[1] - params.blockwidth[d[3]-1]/2 - ((d[0]-1) % params.colnumber[d[3]-1]);})
-        .attr("y", function (d) {return d[2] - params.blockheight[d[3]-1]/2 - Math.floor((d[0]-1) / params.colnumber[d[3]-1]);})
-        .attr("width", function (d) {return params.blockwidth[d[3]-1];})
-        .attr("height", function (d) {return params.blockheight[d[3]-1];})
-        .attr("xlink:href", function (d) {return "https://farm" + d[4] + ".staticflickr.com/" + d[5] + "_o.jpg";});
+        .attr("x", function (d) {return +d.x - params.blockwidth[+d.canvas_id - 1] / 2 - ((+d.id - 1) % params.colnumber[+d.canvas_id - 1]);})
+        .attr("y", function (d) {return +d.y - params.blockheight[+d.canvas_id - 1] / 2 - Math.floor((+d.id - 1) / params.colnumber[+d.canvas_id - 1]);})
+        .attr("width", function (d) {return params.blockwidth[+d.canvas_id - 1];})
+        .attr("height", function (d) {return params.blockheight[+d.canvas_id - 1];})
+        .attr("xlink:href", function (d) {return "https://farm" + d.farm_id + ".staticflickr.com/" + d.url + "_o.jpg";});
 };
 
 var animalCircleRendering = function (svg, data) {
@@ -38,9 +38,9 @@ var animalCircleRendering = function (svg, data) {
         .data(data)
         .enter()
         .append("circle")
-        .attr("cx", function (d) {return d[5];})
-        .attr("cy", function (d) {return d[6];})
-        .attr("r", function (d) {return d[7];})
+        .attr("cx", function (d) {return +d.x;})
+        .attr("cy", function (d) {return +d.y;})
+        .attr("r", function (d) {return +d.r;})
         .attr("fill", "white");
 };
 
@@ -53,46 +53,31 @@ var animalIconRendering = function (svg, data) {
         .append("image")
         .attr("x", function (d) {
             var myPicXO = new Image();
-            myPicXO.src = d[8];
-            return d[5] - myPicXO.width/2;
+            myPicXO.src = d.url;
+            return +d.x - myPicXO.width/2;
         })
         .attr("y", function (d) {
             var myPicXO = new Image();
-            myPicXO.src = d[8];
-            return d[6] - myPicXO.height;
+            myPicXO.src = d.url;
+            return +d.y - myPicXO.height;
         })
-        .attr("xlink:href", function (d) {return d[8];});
+        .attr("xlink:href", function (d) {return d.url;});
     g.selectAll("text")
         .data(data)
         .enter()
         .append("text")
-        .text(function(d) {return d[2];})
-        .attr("x", function(d) {return d[5];})
-        .attr("y", function(d) {return d[6];})
+        .text(function(d) {return d.species;})
+        .attr("x", function(d) {return +d.x;})
+        .attr("y", function(d) {return +d.y;})
         .attr("font-size", "20px")
         .attr("text-anchor", "middle")
         .attr("fill", "white");
 
 };
 
-var svgbackgroundRendering = function (svg, data) {
-
-    g = svg.append("g");
-    g.selectAll("image")
-        .data(data)
-        .enter()
-        .append("path")
-        .attr("d", function (d) {return d[1];})
-        .attr("stroke", function (d) {return d[2];})
-        .attr("stroke-width", "10pt")
-        .attr("fill", function (d) {return d[3];})
-        .attr("transform", function (d) {return "translate(" + (d[4] - 585) + " " + (d[5] - 448) + ")"});
-};
-
 module.exports = {
     renderingParams : renderingParams,
     backgroundRendering : backgroundRendering,
     animalCircleRendering : animalCircleRendering,
-    animalIconRendering : animalIconRendering,
-    svgbackgroundRendering : svgbackgroundRendering
+    animalIconRendering : animalIconRendering
 };

--- a/compiler/examples/forest/renderers.js
+++ b/compiler/examples/forest/renderers.js
@@ -16,9 +16,11 @@ var renderingParams = {
     "pelagic" : [9518, 2017, 562, 1033]
 };
 
-var backgroundRendering = function (svg, data, width, height, params) {
+var backgroundRendering = function (svg, data, args) {
 
     g = svg.append("g");
+    var params = args.renderingParams;
+
     g.selectAll("image")
         .data(data)
         .enter()
@@ -30,7 +32,7 @@ var backgroundRendering = function (svg, data, width, height, params) {
         .attr("xlink:href", function (d) {return "https://farm" + d[4] + ".staticflickr.com/" + d[5] + "_o.jpg";});
 };
 
-var animalCircleRendering = function (svg, data, width, height, params) {
+var animalCircleRendering = function (svg, data) {
     g = svg.append("g");
     g.selectAll("animalcircle")
         .data(data)
@@ -42,18 +44,9 @@ var animalCircleRendering = function (svg, data, width, height, params) {
         .attr("fill", "white");
 };
 
-var animalIconRendering = function (svg, data, width, height, params) {
+var animalIconRendering = function (svg, data) {
 
     g = svg.append("g");
-    // g.selectAll("animalicon")
-    //     .data(data)
-    //     .enter()
-    //     .append("circle")
-    //     .attr("cx", function (d) {return d[5];})
-    //     .attr("cy", function (d) {return d[6];})
-    //     .attr("r", function (d) {return d[7];})
-    //     .attr("fill", "white")
-    //     .style("fill-opacity", 0.5);
     g.selectAll("image")
         .data(data)
         .enter()
@@ -68,18 +61,6 @@ var animalIconRendering = function (svg, data, width, height, params) {
             myPicXO.src = d[8];
             return d[6] - myPicXO.height;
         })
-        /*
-        .attr("width", function (d) {
-            var myPicXO = new Image();
-            myPicXO.src = d[8];
-            return myPicXO.width;
-        })
-        .attr("height", function (d) {
-            var myPicXO = new Image();
-            myPicXO.src = d[8];
-            return myPicXO.height;
-        })
-        */
         .attr("xlink:href", function (d) {return d[8];});
     g.selectAll("text")
         .data(data)
@@ -94,7 +75,7 @@ var animalIconRendering = function (svg, data, width, height, params) {
 
 };
 
-var svgbackgroundRendering = function (svg, data, width, height, params) {
+var svgbackgroundRendering = function (svg, data) {
 
     g = svg.append("g");
     g.selectAll("image")

--- a/compiler/examples/forest/transforms.js
+++ b/compiler/examples/forest/transforms.js
@@ -54,24 +54,6 @@ var c3BackgroundTransform = new Transform("select * from canvas_bg where canvas_
     ["id", "x", "y", "canvas_id", "farm_id", "url"],
     true);
 
-var svgBackgroundTransform = new Transform("select * from svg;",
-    "svg",
-    function (row, width, height, params){
-        var x = parseInt(row[4]) + 585;
-        var y = parseInt(row[5]) + 448;
-        var ret = [];
-        ret.push(row[0]);
-        ret.push(row[1]);
-        ret.push(row[2]);
-        ret.push(row[3]);
-        ret.push(x);
-        ret.push(y);
-
-        return Java.to(ret ,"java.lang.String[]");
-    },
-    ["id", "path", "stroke", "fill", "x", "y"],
-    true);
-
 var c1AnimalTransform = new Transform("select * from animal;",
     "forest",
     function (row, width, height, params){
@@ -137,7 +119,6 @@ module.exports = {
     c1BackgroundTransform : c1BackgroundTransform,
     c2BackgroundTransform : c2BackgroundTransform,
     c3BackgroundTransform : c3BackgroundTransform,
-    svgBackgroundTransform : svgBackgroundTransform,
     c1AnimalTransform : c1AnimalTransform,
     c2AnimalTransform : c2AnimalTransform,
     c3AnimalTransform : c3AnimalTransform

--- a/compiler/examples/nba/nba.js
+++ b/compiler/examples/nba/nba.js
@@ -83,13 +83,14 @@ statsLayer.addPlacement(placements.boxscorePlacement);
 statsLayer.addRenderingFunc(renderers.boxscoreStatsRendering);
 
 // ================== teamlogo -> teamtimeline ===================
-var selector = function (row, layerId) {
-    return (layerId == 0);
+var selector = function () {
+    return true;
 };
 
-var newViewport = function (row) {
+var newViewport = function () {
     return [0, 0, 0]
 };
+
 var newPredicate = function (row) {
     return ["(home_team=\'" + row[6] + "\' or " + "away_team=\'" + row[6] + "\')",
             "abbr=\'" + row[6] + "\'"];
@@ -103,11 +104,11 @@ p.addJump(new Jump(teamLogoCanvas, teamTimelineCanvas, "semantic_zoom", {selecto
     viewport : newViewport, predicates : newPredicate, name : jumpName}));
 
 // ================== teamtimeline -> playbyplay ===================
-var selector = function (row, layerId) {
-    return (layerId == 0);
+var selector = function (row, args) {
+    return (args.layerId == 0);
 };
 
-var newViewport = function (row) {
+var newViewport = function () {
     return [0, 0, 0];
 };
 
@@ -124,8 +125,8 @@ p.addJump(new Jump(teamTimelineCanvas, playByPlayCanvas, "semantic_zoom", {selec
     viewport : newViewport, predicates : newPredicate, name : jumpName}));
 
 // ================== teamtimeline -> boxscore ===================
-var selector = function (row, layerId) {
-    return (layerId == 0);
+var selector = function (row, args) {
+    return (args.layerId == 0);
 };
 
 var newViewport = function () {

--- a/compiler/examples/nba/nba.js
+++ b/compiler/examples/nba/nba.js
@@ -97,7 +97,7 @@ var newPredicate = function (row) {
             {"==" : ["away_team", row.abbr]}
         ]};
     var pred1 = {"==" : ["abbr", row.abbr]};
-    return [pred0, pred1];
+    return {"layer0" : pred0, "layer1" : pred1};
 };
 
 var jumpName = function (row) {
@@ -122,7 +122,7 @@ var newPredicate = function (row) {
             {"==" : ["abbr1", row.home_team]},
             {"==" : ["abbr2", row.away_team]}
         ]};
-    return [pred0, pred1];
+    return {"layer0" : pred0, "layer1" : pred1};
 };
 
 var jumpName = function (row) {
@@ -146,7 +146,7 @@ var newPredicateHome = function (row) {
             {"==" : ["GAME_ID", row.game_id]},
             {"==" : ["TEAM_ABBR", row.home_team]}
         ]};
-    return [pred, pred];
+    return {"layer0" : pred, "layer1" : pred};
 };
 
 var newPredicateAway = function (row) {
@@ -154,7 +154,7 @@ var newPredicateAway = function (row) {
             {"==" : ["GAME_ID", row.game_id]},
             {"==" : ["TEAM_ABBR", row.away_team]}
         ]};
-    return [pred, pred];
+    return {"layer0" : pred, "layer1" : pred};
 };
 
 var jumpNameHome = function (row) {

--- a/compiler/examples/nba/nba.js
+++ b/compiler/examples/nba/nba.js
@@ -99,7 +99,8 @@ var jumpName = function (row) {
     return "2017~2018 Regular Season Games of\n" + row[4] + " " + row[5];
 };
 
-p.addJump(new Jump(teamLogoCanvas, teamTimelineCanvas, selector, newViewport, newPredicate, "semantic_zoom", jumpName));
+p.addJump(new Jump(teamLogoCanvas, teamTimelineCanvas, "semantic_zoom", {selector : selector,
+    viewport : newViewport, predicates : newPredicate, name : jumpName}));
 
 // ================== teamtimeline -> playbyplay ===================
 var selector = function (row, layerId) {
@@ -107,7 +108,7 @@ var selector = function (row, layerId) {
 };
 
 var newViewport = function (row) {
-    return [0, 0, 0]
+    return [0, 0, 0];
 };
 
 var newPredicate = function (row) {
@@ -119,7 +120,8 @@ var jumpName = function (row) {
     return "Scoring Plays of " + row[7] + "@" + row[6];
 };
 
-p.addJump(new Jump(teamTimelineCanvas, playByPlayCanvas, selector, newViewport, newPredicate, "semantic_zoom", jumpName));
+p.addJump(new Jump(teamTimelineCanvas, playByPlayCanvas, "semantic_zoom", {selector : selector,
+    viewport : newViewport, predicates : newPredicate, name : jumpName}));
 
 // ================== teamtimeline -> boxscore ===================
 var selector = function (row, layerId) {
@@ -148,8 +150,10 @@ var jumpNameAway = function (row) {
     return "Box score of " + row[7];
 };
 
-p.addJump(new Jump(teamTimelineCanvas, boxscoreCanvas, selector, newViewport, newPredicateHome, "semantic_zoom", jumpNameHome));
-p.addJump(new Jump(teamTimelineCanvas, boxscoreCanvas, selector, newViewport, newPredicateAway, "semantic_zoom", jumpNameAway));
+p.addJump(new Jump(teamTimelineCanvas, boxscoreCanvas, "semantic_zoom", {selector : selector,
+    viewport : newViewport, predicates : newPredicateHome, name : jumpNameHome}));
+p.addJump(new Jump(teamTimelineCanvas, boxscoreCanvas, "semantic_zoom", {selector : selector,
+    viewport : newViewport, predicates : newPredicateAway, name : jumpNameAway}));
 
 // setting up initial states
 p.setInitialStates(teamLogoCanvas, 0, 0, [""]);

--- a/compiler/examples/nba/nba.js
+++ b/compiler/examples/nba/nba.js
@@ -92,12 +92,12 @@ var newViewport = function () {
 };
 
 var newPredicate = function (row) {
-    return ["(home_team=\'" + row[6] + "\' or " + "away_team=\'" + row[6] + "\')",
-            "abbr=\'" + row[6] + "\'"];
+    return ["(home_team=\'" + row.abbr + "\' or " + "away_team=\'" + row.abbr + "\')",
+            "abbr=\'" + row.abbr + "\'"];
 };
 
 var jumpName = function (row) {
-    return "2017~2018 Regular Season Games of\n" + row[4] + " " + row[5];
+    return "2017~2018 Regular Season Games of\n" + row.city + " " + row.name;
 };
 
 p.addJump(new Jump(teamLogoCanvas, teamTimelineCanvas, "semantic_zoom", {selector : selector,
@@ -113,12 +113,12 @@ var newViewport = function () {
 };
 
 var newPredicate = function (row) {
-    return ["game_id = \'" + row[0] + "\'",
-            "abbr1=\'" + row[6] + "\' and abbr2=\'" + row[7] + "\'"];
+    return ["game_id = \'" + row.game_id + "\'",
+            "abbr1=\'" + row.home_team + "\' and abbr2=\'" + row.away_team + "\'"];
 };
 
 var jumpName = function (row) {
-    return "Scoring Plays of " + row[7] + "@" + row[6];
+    return "Play-by-Play of " + row.away_team + "@" + row.home_team;
 };
 
 p.addJump(new Jump(teamTimelineCanvas, playByPlayCanvas, "semantic_zoom", {selector : selector,
@@ -134,21 +134,21 @@ var newViewport = function () {
 };
 
 var newPredicateHome = function (row) {
-    return ["game_id = \'" + row[0] + "\' and team_abbreviation = \'" + row[6] + "\'",
-        "game_id = \'" + row[0] + "\' and team_abbreviation = \'" + row[6] + "\'"];
+    return ["GAME_ID = \'" + row.game_id + "\' and TEAM_ABBR = \'" + row.home_team + "\'",
+        "GAME_ID = \'" + row.game_id + "\' and TEAM_ABBR = \'" + row.home_team + "\'"];
 };
 
 var newPredicateAway = function (row) {
-    return ["game_id = \'" + row[0] + "\' and team_abbreviation = \'" + row[7] + "\'",
-        "game_id = \'" + row[0] + "\' and team_abbreviation = \'" + row[7] + "\'"];
+    return ["GAME_ID = \'" + row.game_id + "\' and TEAM_ABBR = \'" + row.away_team + "\'",
+        "GAME_ID = \'" + row.game_id + "\' and TEAM_ABBR = \'" + row.away_team + "\'"];
 };
 
 var jumpNameHome = function (row) {
-    return "Box score of " + row[6];
+    return "Box score of " + row.home_team;
 };
 
 var jumpNameAway = function (row) {
-    return "Box score of " + row[7];
+    return "Box score of " + row.away_team;
 };
 
 p.addJump(new Jump(teamTimelineCanvas, boxscoreCanvas, "semantic_zoom", {selector : selector,

--- a/compiler/examples/nba/nba.js
+++ b/compiler/examples/nba/nba.js
@@ -88,7 +88,7 @@ var selector = function () {
 };
 
 var newViewport = function () {
-    return [0, 0, 0]
+    return {"constant" : [0, 0]};
 };
 
 var newPredicate = function (row) {
@@ -113,7 +113,7 @@ var selector = function (row, args) {
 };
 
 var newViewport = function () {
-    return [0, 0, 0];
+    return {"constant" : [0, 0]};
 };
 
 var newPredicate = function (row) {
@@ -138,7 +138,7 @@ var selector = function (row, args) {
 };
 
 var newViewport = function () {
-    return [0, 0, 0]
+    return {"constant" : [0, 0]};
 };
 
 var newPredicateHome = function (row) {

--- a/compiler/examples/nba/nba.js
+++ b/compiler/examples/nba/nba.js
@@ -92,8 +92,12 @@ var newViewport = function () {
 };
 
 var newPredicate = function (row) {
-    return ["(home_team=\'" + row.abbr + "\' or " + "away_team=\'" + row.abbr + "\')",
-            "abbr=\'" + row.abbr + "\'"];
+    var pred0 = {"OR" : [
+            {"==" : ["home_team", row.abbr]},
+            {"==" : ["away_team", row.abbr]}
+        ]};
+    var pred1 = {"==" : ["abbr", row.abbr]};
+    return [pred0, pred1];
 };
 
 var jumpName = function (row) {
@@ -113,8 +117,12 @@ var newViewport = function () {
 };
 
 var newPredicate = function (row) {
-    return ["game_id = \'" + row.game_id + "\'",
-            "abbr1=\'" + row.home_team + "\' and abbr2=\'" + row.away_team + "\'"];
+    var pred0 = {"==" : ["game_id", row.game_id]};
+    var pred1 = {"AND" : [
+            {"==" : ["abbr1", row.home_team]},
+            {"==" : ["abbr2", row.away_team]}
+        ]};
+    return [pred0, pred1];
 };
 
 var jumpName = function (row) {
@@ -134,13 +142,19 @@ var newViewport = function () {
 };
 
 var newPredicateHome = function (row) {
-    return ["GAME_ID = \'" + row.game_id + "\' and TEAM_ABBR = \'" + row.home_team + "\'",
-        "GAME_ID = \'" + row.game_id + "\' and TEAM_ABBR = \'" + row.home_team + "\'"];
+    var pred = {"AND" : [
+            {"==" : ["GAME_ID", row.game_id]},
+            {"==" : ["TEAM_ABBR", row.home_team]}
+        ]};
+    return [pred, pred];
 };
 
 var newPredicateAway = function (row) {
-    return ["GAME_ID = \'" + row.game_id + "\' and TEAM_ABBR = \'" + row.away_team + "\'",
-        "GAME_ID = \'" + row.game_id + "\' and TEAM_ABBR = \'" + row.away_team + "\'"];
+    var pred = {"AND" : [
+            {"==" : ["GAME_ID", row.game_id]},
+            {"==" : ["TEAM_ABBR", row.away_team]}
+        ]};
+    return [pred, pred];
 };
 
 var jumpNameHome = function (row) {
@@ -157,7 +171,7 @@ p.addJump(new Jump(teamTimelineCanvas, boxscoreCanvas, "semantic_zoom", {selecto
     viewport : newViewport, predicates : newPredicateAway, name : jumpNameAway}));
 
 // setting up initial states
-p.setInitialStates(teamLogoCanvas, 0, 0, [""]);
+p.setInitialStates(teamLogoCanvas, 0, 0);
 
 // save to db
 p.saveProject();

--- a/compiler/examples/nba/renderers.js
+++ b/compiler/examples/nba/renderers.js
@@ -67,7 +67,7 @@ var teamLogoRendering = function (svg, data) {
         .attr("xlink:href", function (d) {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + d[6] + ".svg";});
 };
 
-var teamTimelineRendering = function (svg, data, width, height, params) {
+var teamTimelineRendering = function (svg, data, args) {
 
     var rectWidth = 160;
     var rectHeight = 100;
@@ -82,6 +82,7 @@ var teamTimelineRendering = function (svg, data, width, height, params) {
     var d2Delta = 15;
 
     g = svg.append("g");
+    var params = args.renderingParams;
 
     // rect background
     g.selectAll("rect")
@@ -174,7 +175,7 @@ var teamTimelineRendering = function (svg, data, width, height, params) {
         .style("stroke-width", 3);
 };
 
-var playByPlayRendering = function (svg, data, width, height, params) {
+var playByPlayRendering = function (svg, data, args) {
 
     var centerTextWidth = 100;
     var centerTextHeight = 100;
@@ -196,6 +197,8 @@ var playByPlayRendering = function (svg, data, width, height, params) {
         "OT 1", "OT 2", "OT 3", "OT 4", "OT 5", "OT 6"];
 
     var g = svg.append("g");
+    var params = args.renderingParams;
+    var height = args.canvasH;
 
     // extract home plays and away plays
     var homePlays = [], awayPlays = [];
@@ -450,10 +453,12 @@ var playByPlayStaticBkg = function (svg, data) {
         .style("opacity", 0.07);
 };
 
-var boxscorePkRendering = function (svg, data, width, height, params) {
+var boxscorePkRendering = function (svg, data, args) {
 
     // create a new g
     var g = svg.append("g");
+    var height = args.canvasH;
+    var params = args.renderingParams;
 
     // precompute some stuff
     var headerStartHeight = height / 2 - ((data.length + 1) * params.cellHeight + params.headerHeight) / 2;
@@ -584,10 +589,12 @@ var boxscorePkRendering = function (svg, data, width, height, params) {
         .style("fill", "white");
 };
 
-var boxscoreStatsRendering = function (svg, data, width, height, params) {
+var boxscoreStatsRendering = function (svg, data, args) {
 
     // create a new g
     var g = svg.append("g");
+    var height = args.canvasH;
+    var params = args.renderingParams;
 
     // precompute some stuff
     var headerStartHeight = height / 2 - ((data.length + 1) * params.cellHeight + params.headerHeight) / 2;

--- a/compiler/examples/nba/renderers.js
+++ b/compiler/examples/nba/renderers.js
@@ -457,7 +457,7 @@ var boxscorePkRendering = function (svg, data, args) {
 
     // create a new g
     var g = svg.append("g");
-    var height = args.canvasH;
+    var height = args.viewportH;
     var params = args.renderingParams;
 
     // precompute some stuff

--- a/compiler/examples/nba/renderers.js
+++ b/compiler/examples/nba/renderers.js
@@ -60,11 +60,11 @@ var teamLogoRendering = function (svg, data) {
         .data(data)
         .enter()
         .append("image")
-        .attr("x", function (d) {return d[1] - 65;})
-        .attr("y", function (d) {return d[2] - 65;})
+        .attr("x", function (d) {return d.x - 65;})
+        .attr("y", function (d) {return d.y - 65;})
         .attr("width", 130)
         .attr("height", 130)
-        .attr("xlink:href", function (d) {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + d[6] + ".svg";});
+        .attr("xlink:href", function (d) {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + d.abbr + ".svg";});
 };
 
 var teamTimelineRendering = function (svg, data, args) {
@@ -89,8 +89,8 @@ var teamTimelineRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("rect")
-        .attr("x", function (d) {return d[1] - rectWidth / 2;})
-        .attr("y", function (d) {return d[2] - d2Delta - rectHeight / 2;})
+        .attr("x", function (d) {return +d.x - rectWidth / 2;})
+        .attr("y", function (d) {return +d.y - d2Delta - rectHeight / 2;})
         .attr("rx", 10)
         .attr("ry", 10)
         .attr("width", rectWidth)
@@ -104,31 +104,31 @@ var teamTimelineRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("image")
-        .attr("x", function (d) {return d[1] - logoXDelta;})
-        .attr("y", function (d) {return d[2] - d2Delta - logoYDelta - logoSize;})
+        .attr("x", function (d) {return +d.x - logoXDelta;})
+        .attr("y", function (d) {return +d.y - d2Delta - logoYDelta - logoSize;})
         .attr("width", logoSize)
         .attr("height", logoSize)
-        .attr("xlink:href", function (d) {return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d[6] + ".svg";});
+        .attr("xlink:href", function (d) {return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d.home_team + ".svg";});
 
     // away logo
     g.selectAll(".awayimage")
         .data(data)
         .enter()
         .append("image")
-        .attr("x", function (d) {return d[1] - logoXDelta;})
-        .attr("y", function (d) {return d[2] - d2Delta + logoYDelta;})
+        .attr("x", function (d) {return +d.x - logoXDelta;})
+        .attr("y", function (d) {return +d.y - d2Delta + logoYDelta;})
         .attr("width", logoSize)
         .attr("height", logoSize)
-        .attr("xlink:href", function (d) {return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d[7] + ".svg";});
+        .attr("xlink:href", function (d) {return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d.away_team + ".svg";});
 
     // home score
     g.selectAll(".homescore")
         .data(data)
         .enter()
         .append("text")
-        .text(function(d) {return d[8]})
-        .attr("x", function(d) {return +d[1] + scoreXDelta;})
-        .attr("y", function(d) {return d[2] - d2Delta - scoreYDelta;})
+        .text(function(d) {return d.home_score})
+        .attr("x", function(d) {return +d.x + scoreXDelta;})
+        .attr("y", function(d) {return +d.y - d2Delta - scoreYDelta;})
         .attr("font-size", scoreFontSize)
         .attr("dy", ".35em")
         .attr("text-anchor", "end")
@@ -139,9 +139,9 @@ var teamTimelineRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("text")
-        .text(function(d) {return d[9]})
-        .attr("x", function(d) {return +d[1] + scoreXDelta;})
-        .attr("y", function(d) {return d[2] - d2Delta + scoreYDelta;})
+        .text(function(d) {return d.away_score})
+        .attr("x", function(d) {return +d.x + scoreXDelta;})
+        .attr("y", function(d) {return +d.y - d2Delta + scoreYDelta;})
         .attr("font-size", scoreFontSize)
         .attr("dy", ".35em")
         .attr("text-anchor", "end")
@@ -152,9 +152,9 @@ var teamTimelineRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("text")
-        .text(function (d) {return d3.timeFormat("%B %d, %Y")(new Date(d[3], d[4] - 1, d[5]));})
-        .attr("x", function (d) {return +d[1];})
-        .attr("y", function (d) {return d[2] - d2Delta + rectHeight / 2 + dateYDelta;})
+        .text(function (d) {return d3.timeFormat("%B %d, %Y")(new Date(+d.year, +d.month - 1, +d.day));})
+        .attr("x", function (d) {return +d.x;})
+        .attr("y", function (d) {return +d.y - d2Delta + rectHeight / 2 + dateYDelta;})
         .attr("dy", ".35em")
         .attr("text-anchor", "middle")
         .style("fill-opacity", 1);
@@ -164,12 +164,12 @@ var teamTimelineRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("line")
-        .attr("x1", function (d) {return d[1];})
-        .attr("x2", function (d) {return d[1];})
+        .attr("x1", function (d) {return +d.x;})
+        .attr("x2", function (d) {return +d.x;})
         .attr("y1", 625)
         .attr("y2", function (d) {
-            if (d[2] == params.timelineUpperY) return d[2] - d2Delta + rectHeight / 2 + dateHeight;
-            return d[2] - d2Delta - rectHeight / 2;
+            if (+d.y == params.timelineUpperY) return +d.y - d2Delta + rectHeight / 2 + dateHeight;
+            return +d.y - d2Delta - rectHeight / 2;
         })
         .style("stroke", "#CCC")
         .style("stroke-width", 3);
@@ -203,9 +203,9 @@ var playByPlayRendering = function (svg, data, args) {
     // extract home plays and away plays
     var homePlays = [], awayPlays = [];
     for (var i = 0; i < data.length; i ++) {
-        if (data[i][6] != "None")
+        if (data[i].home_desc != "None")
             homePlays.push(data[i]);
-        if (data[i][7] != "None")
+        if (data[i].away_desc != "None")
             awayPlays.push(data[i]);
     }
 
@@ -215,7 +215,7 @@ var playByPlayRendering = function (svg, data, args) {
         .enter()
         .append("path")
         .attr("d", function (d) {
-            var path = "M " + (500 - centerTextWidth / 2) + " " + d[1];
+            var path = "M " + (500 - centerTextWidth / 2) + " " + d.y;
             path += " l " + (-triangleWidth) + " " + (-radius);
             path += " h " + (-descBoxWidth);
             path += " a " + radius + " " + radius + " 0 0 0 " + "0 " + triangleHeight;
@@ -233,7 +233,7 @@ var playByPlayRendering = function (svg, data, args) {
         .enter()
         .append("path")
         .attr("d", function (d) {
-            var path = "M " + (500 + centerTextWidth / 2) + " " + d[1];
+            var path = "M " + (500 + centerTextWidth / 2) + " " + d.y;
             path += " l " + triangleWidth + " " + (-radius);
             path += " h " + descBoxWidth;
             path += " a " + radius + " " + radius + " 0 0 1 " + "0 " + triangleHeight;
@@ -264,13 +264,13 @@ var playByPlayRendering = function (svg, data, args) {
         .append("image")
         .classed("homeimage", true)
         .attr("x", 500 - centerTextWidth / 2 - triangleWidth - descBoxWidth + imageOffset - (radius * 2 - imageMargin) / 2)
-        .attr("y", function (d) {return d[1] - (radius * 2 - imageMargin) / 2;})
+        .attr("y", function (d) {return +d.y - (radius * 2 - imageMargin) / 2;})
         .attr("width", radius * 2 - imageMargin)
         .attr("height", radius * 2 - imageMargin)
         .attr("xlink:href", function (d) {
-            if (d[10] == "None")
-                return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d[8] + ".svg";
-            return "http://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/" + d[10] + ".png";
+            if (d.h_player_id == "None")
+                return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d.home_team + ".svg";
+            return "http://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/" + d.h_player_id + ".png";
         })
         .style("mask", "url(#circlemask)");
 
@@ -281,13 +281,13 @@ var playByPlayRendering = function (svg, data, args) {
         .append("image")
         .classed("awayimage", true)
         .attr("x", 500 + centerTextWidth / 2 + triangleWidth + descBoxWidth -imageOffset - (radius * 2 - imageMargin) / 2)
-        .attr("y", function (d) {return d[1] - (radius * 2 - imageMargin) / 2;})
+        .attr("y", function (d) {return +d.y - (radius * 2 - imageMargin) / 2;})
         .attr("width", radius * 2 - imageMargin)
         .attr("height", radius * 2 - imageMargin)
         .attr("xlink:href", function (d) {
-            if (d[11] == "None")
-                return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d[9] + ".svg";
-            return "http://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/" + d[11] + ".png";
+            if (d.a_player_id == "None")
+                return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d.away_team + ".svg";
+            return "http://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/" + d.a_player_id + ".png";
         })
         .style("mask", "url(#circlemask)");
 
@@ -296,9 +296,9 @@ var playByPlayRendering = function (svg, data, args) {
         .data(homePlays)
         .enter()
         .append("text")
-        .text(function (d) {return d[6];})
+        .text(function (d) {return d.home_desc;})
         .attr("x", 500 - centerTextWidth / 2 - triangleWidth - descBoxWidth / 2 + descOffset)
-        .attr("y", function (d) {return d[1];})
+        .attr("y", function (d) {return +d.y;})
         .attr("font-size", descFontSize)
         .attr("dy", ".35em")
         .attr("text-anchor", "middle")
@@ -310,9 +310,9 @@ var playByPlayRendering = function (svg, data, args) {
         .data(awayPlays)
         .enter()
         .append("text")
-        .text(function (d) {return d[7];})
+        .text(function (d) {return d.away_desc;})
         .attr("x", 500 + centerTextWidth / 2 + triangleWidth + descBoxWidth / 2 - descOffset)
-        .attr("y", function (d) {return d[1];})
+        .attr("y", function (d) {return +d.y;})
         .attr("font-size", descFontSize)
         .attr("dy", ".35em")
         .attr("text-anchor", "middle")
@@ -327,7 +327,7 @@ var playByPlayRendering = function (svg, data, args) {
         .attr("width", centerTextWidth)
         .attr("height", centerTextHeight)
         .attr("x", 500 - centerTextWidth / 2)
-        .attr("y", function (d) {return d[1] - centerTextHeight / 2;})
+        .attr("y", function (d) {return +d.y - centerTextHeight / 2;})
         .attr("fill", "white");
 
     // center text
@@ -335,9 +335,9 @@ var playByPlayRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("text")
-        .text(function (d) {return qtr_text[d[2] - 1];})
+        .text(function (d) {return qtr_text[+d.period - 1];})
         .attr("x", 500)
-        .attr("y", function (d) {return d[1] - qtrTextYDelta;})
+        .attr("y", function (d) {return +d.y - qtrTextYDelta;})
         .attr("font-size", qtrTextFontSize)
         .attr("dy", ".35em")
         .attr("text-anchor", "middle")
@@ -347,9 +347,9 @@ var playByPlayRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("text")
-        .text(function (d) {return d[3];})
+        .text(function (d) {return d.qtr_time;})
         .attr("x", 500)
-        .attr("y", function (d) {return d[1];})
+        .attr("y", function (d) {return +d.y;})
         .attr("font-size", qtrTimeFontSize)
         .attr("dy", ".35em")
         .attr("text-anchor", "middle")
@@ -359,9 +359,9 @@ var playByPlayRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("text")
-        .text(function (d) {return d[4];})
+        .text(function (d) {return d.score;})
         .attr("x", 500)
-        .attr("y", function (d) {return +d[1] + scoreYDelta;})
+        .attr("y", function (d) {return +d.y + scoreYDelta;})
         .attr("font-size", scoreFontSize)
         .attr("dy", ".35em")
         .attr("text-anchor", "middle")
@@ -374,7 +374,7 @@ var playByPlayRendering = function (svg, data, args) {
         .enter()
         .append("circle")
         .attr("cx", 500 - centerTextWidth / 2)
-        .attr("cy", function (d) {return d[1];})
+        .attr("cy", function (d) {return +d.y;})
         .attr("r", frameCircleR)
         .style("fill", "#221f56");
 
@@ -383,7 +383,7 @@ var playByPlayRendering = function (svg, data, args) {
         .enter()
         .append("circle")
         .attr("cx", 500 + centerTextWidth / 2)
-        .attr("cy", function (d) {return d[1];})
+        .attr("cy", function (d) {return +d.y;})
         .attr("r", frameCircleR)
         .style("fill", "#221f56");
 
@@ -403,7 +403,7 @@ var teamTimelineStaticBkg = function (svg, data) {
         .html("2017~2018 Regular Season Games");
     title.append("tspan")
         .attr("x", 500)
-        .attr("dy", 70).html(data[0][0] + " " + data[0][1]);
+        .attr("dy", 70).html(data[0].city + " " + data[0].name);
 
     // axis line
     g.append("line")
@@ -420,7 +420,7 @@ var teamTimelineStaticBkg = function (svg, data) {
         .attr("y", 0)
         .attr("width", 1000)
         .attr("height", 1000)
-        .attr("xlink:href", function (d) {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + data[0][2] + ".svg";})
+        .attr("xlink:href", function () {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + data[0].abbr + ".svg";})
         .style("opacity", 0.07);
 };
 
@@ -442,14 +442,14 @@ var playByPlayStaticBkg = function (svg, data) {
         .attr("y", 300)
         .attr("width", 400)
         .attr("height", 400)
-        .attr("xlink:href", function (d) {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + data[0][0] + ".svg";})
+        .attr("xlink:href", function (d) {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + data[0].abbr1 + ".svg";})
         .style("opacity", 0.07);
     g.append("image")
         .attr("x", 550)
         .attr("y", 300)
         .attr("width", 400)
         .attr("height", 400)
-        .attr("xlink:href", function (d) {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + data[0][1] + ".svg";})
+        .attr("xlink:href", function (d) {return "https://rawgit.com/tracyhenry/f0c8534bb87c6b48a8b9ee167b3a102f/raw/7724c716788e5e08079e0ec70bd0ecf834bbffea/" + data[0].abbr2 + ".svg";})
         .style("opacity", 0.07);
 };
 
@@ -530,9 +530,9 @@ var boxscorePkRendering = function (svg, data, args) {
             return firstRowHeight + (i + 0.5) * params.cellHeight - params.playerphotoradius;
         })
         .attr("xlink:href", function (d) {
-            if (d[5] == "None")
-                return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d[3] + ".svg";
-            return "http://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/" + d[5] + ".png";
+            if (d.PLAYER_ID == "None")
+                return "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + d.TEAM_ABBR + ".svg";
+            return "http://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/" + d.PLAYER_ID + ".png";
         })
         .style("mask", "url(#circlemask)");
 
@@ -541,7 +541,7 @@ var boxscorePkRendering = function (svg, data, args) {
         .data(data)
         .enter()
         .append("text")
-        .text(function(d) {return d[6];})
+        .text(function(d) {return d.PLAYER_NAME;})
         .attr("x", function (){
             var textLeft = params.playerphotoleftmargin + params.playerphotoradius * 2;
             //return (params.playerNameCellWidth - textLeft) / 2 + textLeft;
@@ -577,7 +577,7 @@ var boxscorePkRendering = function (svg, data, args) {
             .attr("y", startHeight + params.cellHeight / 2 - params.teamlogoradius)
             .attr("width", params.teamlogoradius * 2)
             .attr("height", params.teamlogoradius * 2)
-            .attr("xlink:href", "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + data[0][3] + ".svg");
+            .attr("xlink:href", "https://i.cdn.turner.com/nba/nba/assets/logos/teams/secondary/web/" + data[0].TEAM_ABBR + ".svg");
     }
 
     // shadow rect
@@ -600,17 +600,21 @@ var boxscoreStatsRendering = function (svg, data, args) {
     var headerStartHeight = height / 2 - ((data.length + 1) * params.cellHeight + params.headerHeight) / 2;
     var firstRowHeight = headerStartHeight + params.headerHeight;
     var avg_fields = ["FG_PCT", "FG3_PCT", "FT_PCT"];
-    var fields = ['id', 'GAME_ID', 'TEAM_ID', 'TEAM_ABBREVIATION', 'TEAM_CITY', 'PLAYER_ID', 'PLAYER_NAME', 'POS', 'MIN', 'PTS', 'FGM', 'FGA', 'FG_PCT', 'FG3M', 'FG3A', 'FG3_PCT', 'FTM', 'FTA', 'FT_PCT', 'OREB', 'DREB', 'REB', 'AST', 'STL', 'BLK', 'TO', 'PF', '+/-'];
+    var fields = ['id', 'GAME_ID', 'TEAM_ID', 'TEAM_ABBR', 'TEAM_CITY', 'PLAYER_ID', 'PLAYER_NAME', 'POS', 'MIN', 'PTS', 'FGM', 'FGA', 'FG_PCT', 'FG3M', 'FG3A', 'FG3_PCT', 'FTM', 'FTA', 'FT_PCT', 'OREB', 'DREB', 'REB', 'AST', 'STL', 'BLK', 'TURNOVER', 'PF', 'PLUS_MINUS'];
 
     // loop over stats
     var curLeft = params.playerNameCellWidth;
     for (var i = 7; i < fields.length; i ++) {
+
         // get precision
         var precision = 0;
         if (avg_fields.indexOf(fields[i]) != -1)
             precision = 2;
 
-        var curColumnWidth = Math.min(fields[i].length * params.avgcharwidth, params.statsCellMaxWidth);
+        // display name of the current field
+        var displayName = (fields[i] == 'TURNOVER' ? 'TO' : (fields[i] == 'PLUS_MINUS' ? '+/-' : fields[i]));
+
+        var curColumnWidth = Math.min(displayName.length * params.avgcharwidth, params.statsCellMaxWidth);
         // stats header bkg rect
         g.append("rect")
             .attr("width", curColumnWidth)
@@ -621,7 +625,7 @@ var boxscoreStatsRendering = function (svg, data, args) {
 
         // stats header text
         g.append("text")
-            .text(fields[i])
+            .text(displayName)
             .attr("x", curLeft + curColumnWidth / 2)
             .attr("y", headerStartHeight + params.headerHeight / 2)
             .attr("dy", ".35em")
@@ -652,7 +656,7 @@ var boxscoreStatsRendering = function (svg, data, args) {
             .enter()
             .append("text")
             .text(function (d) {
-                return (fields[i] == 'POS' ? d[i] : (+d[i]).toFixed(precision));
+                return (fields[i] == 'POS' ? d[fields[i]] : (+d[fields[i]]).toFixed(precision));
             })
             .attr("x", curLeft + curColumnWidth / 2)
             .attr("y", function (d, i) {
@@ -679,10 +683,10 @@ var boxscoreStatsRendering = function (svg, data, args) {
         if (fields[i] != 'POS') {
             var overall = 0;
             for (var j = 0; j < data.length; j ++)
-                overall += +data[j][i];
+                overall += +data[j][fields[i]];
             if (avg_fields.indexOf(fields[i]) != -1)
                 overall = overall / data.length;
-            else if (fields[i] == "+/-")
+            else if (fields[i] == "PLUS_MINUS")
                 overall = overall / 5;
             g.append("text")
                 .text(overall.toFixed(precision))

--- a/compiler/examples/nba/transforms.js
+++ b/compiler/examples/nba/transforms.js
@@ -98,7 +98,7 @@ var playByPlayStaticTransform = new Transform("select team1.abbr, team2.abbr fro
 var boxscoreTransform = new Transform("select * from player_boxscore",
     "nba",
     "",
-    ['id', 'GAME_ID', 'TEAM_ID', 'TEAM_ABBREVIATION', 'TEAM_CITY', 'PLAYER_ID', 'PLAYER_NAME', 'START_POSITION', 'MIN', 'PTS', 'FGM', 'FGA', 'FG_PCT', 'FG3M', 'FG3A', 'FG3_PCT', 'FTM', 'FTA', 'FT_PCT', 'OREB', 'DREB', 'REB', 'AST', 'STL', 'BLK', 'TUNROVER', 'PF', 'PLUS_MINUS'],
+    ['id', 'GAME_ID', 'TEAM_ID', 'TEAM_ABBR', 'TEAM_CITY', 'PLAYER_ID', 'PLAYER_NAME', 'POS', 'MIN', 'PTS', 'FGM', 'FGA', 'FG_PCT', 'FG3M', 'FG3A', 'FG3_PCT', 'FTM', 'FTA', 'FT_PCT', 'OREB', 'DREB', 'REB', 'AST', 'STL', 'BLK', 'TURNOVER', 'PF', 'PLUS_MINUS'],
     true);
 
 module.exports = {

--- a/compiler/src/Canvas.js
+++ b/compiler/src/Canvas.js
@@ -14,6 +14,7 @@ function Canvas(id, w, h, wString, hString) {
         throw new Error("Constructing canvas: h must be a positive integer.");
     if (w == 0) {
         wString = processWidthHeightString(wString);
+        this.w = -1;
         this.wLayerId = wString.split(":")[0];
         this.wSql = wString.substring(this.wLayerId.length + 1);
     }
@@ -23,6 +24,7 @@ function Canvas(id, w, h, wString, hString) {
 
     if (h == 0) {
         hString = processWidthHeightString(hString);
+        this.h = -1;
         this.hLayerId = hString.split(":")[0];
         this.hSql = hString.substring(this.hLayerId.length + 1);
     }

--- a/compiler/src/Jump.js
+++ b/compiler/src/Jump.js
@@ -9,11 +9,14 @@ function Jump(sourceCanvas, destCanvas, type, optional) {
 
     if (optional == null)
         optional = {};
-    // check canvas objects have ids
+    // check must-have fields
     if (sourceCanvas.id == null || destCanvas.id == null)
         throw new Error("Constructing Jump: unidentified source or destination canvas.");
     if (type == null)
-        throw new Error("Constructing Jump: jump type is missing.");
+        throw new Error("Constructing Jump: missing jump type.");
+    if (type == "semantic_zoom" || type == "geometric_semantic_zoom")
+        if (! ("selector" in optional) || ! ("viewport" in optional) || ! ("predicates" in optional))
+            throw new Error("Constructing Jump: missing customization functions for semantic zoom.");
 
     this.type = type;
     this.sourceId = sourceCanvas.id;

--- a/compiler/src/Jump.js
+++ b/compiler/src/Jump.js
@@ -7,13 +7,15 @@
  */
 function Jump(sourceCanvas, destCanvas, type, optional) {
 
-    if (optional == null)
-        optional = {};
     // check must-have fields
     if (sourceCanvas.id == null || destCanvas.id == null)
         throw new Error("Constructing Jump: unidentified source or destination canvas.");
     if (type == null)
         throw new Error("Constructing Jump: missing jump type.");
+    if ((type == "literal_zoom_in" || type == "literal_zoom_out") && (optional != null))
+        throw new Error("Constructing Jump: literal zooms do not need optional arguments.");
+    if (optional == null)
+        optional = {};
     if (type == "semantic_zoom" || type == "geometric_semantic_zoom")
         if (! ("selector" in optional) || ! ("viewport" in optional) || ! ("predicates" in optional))
             throw new Error("Constructing Jump: missing customization functions for semantic zoom.");

--- a/compiler/src/Jump.js
+++ b/compiler/src/Jump.js
@@ -2,29 +2,26 @@
  * Construct jump transition between two canvases
  * @param {object} sourceCanvas - the source canvas object
  * @param {object} destCanvas - the destination canvas object
- * @param {function} selector - a javascript function deciding whether a tuple should trigger this jump
- * @param {function} newViewports - a javascript function calculating the new viewport (see api doc for more details)
- * @param {function} newPredicates - a javascript function calculating predicates for the new canvas
- * @param {string} type - a string indicating the type of this jump, could be one of "literal_zoom_in", "literal_zoom_out", "semantic_zoom" or "geometric_semantic_zoom (or maybe something else in the future)
- * @param {string}/{function} name - the name of this jump, could be a string, or a function taking the jumping entity as input and returning the name.
+ * @param {object} optional - a dictionary of optional arguments, including zoom type, selector, predicate, viewport and name functions.
  * @constructor
  */
-function Jump(sourceCanvas, destCanvas, selector, newViewports, newPredicates, type, name) {
+function Jump(sourceCanvas, destCanvas, type, optional) {
 
+    if (optional == null)
+        optional = {};
     // check canvas objects have ids
     if (sourceCanvas.id == null || destCanvas.id == null)
         throw new Error("Constructing Jump: unidentified source or destination canvas.");
+    if (type == null)
+        throw new Error("Constructing Jump: jump type is missing.");
 
+    this.type = type;
     this.sourceId = sourceCanvas.id;
     this.destId = destCanvas.id;
-    this.selector = selector;
-    this.newViewports = newViewports;
-    this.newPredicates = newPredicates;
-    this.type = type;
-    if (name != null)
-        this.name = name;
-    else
-        this.name = destCanvas.id;
+    this.selector = ("selector" in optional ? optional["selector"] : "");
+    this.newViewports = ("viewport" in optional ? optional["viewport"] : "");
+    this.newPredicates = ("predicates" in optional ? optional["predicates"] : "");
+    this.name = ("name" in optional ? optional["name"] : destCanvas.id);
 };
 
 // exports

--- a/compiler/src/Transform.js
+++ b/compiler/src/Transform.js
@@ -18,8 +18,6 @@ function Transform(query, db, transformFunc, columnNames, separable) {
     this.columnNames = columnNames;
     this.transformFunc = transformFunc;
     this.separable = separable;
-
-    //TODO: check column names are valid JS dictionary key names
 };
 
 defaultEmptyTransform = new Transform("", "", "", [], true);

--- a/compiler/src/Transform.js
+++ b/compiler/src/Transform.js
@@ -18,6 +18,8 @@ function Transform(query, db, transformFunc, columnNames, separable) {
     this.columnNames = columnNames;
     this.transformFunc = transformFunc;
     this.separable = separable;
+
+    //TODO: check column names are valid JS dictionary key names
 };
 
 defaultEmptyTransform = new Transform("", "", "", [], true);

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -163,23 +163,14 @@ function setInitialStates(canvasObj, viewportX, viewportY, predicates) {
         throw new Error("Initial canvas: viewportY out of range.");
 
     // check if the size of the predicates array equals the number of layers
-    if (predicates == null) {
-        predicates = [];
-        for (var i = 0; i < this.canvases[canvasId].layers.length; i ++)
-            predicates.push({});
-    }
-    if (predicates.length != this.canvases[canvasId].layers.length)
-        throw new Error("Initial canvas: # predicates does not equal # layers.");
-
-    // serialize initial predicates into strings, so that gson (in the backend) can recognize
-    for (var i = 0; i < predicates.length; i ++)
-        predicates[i] = JSON.stringify(predicates[i]);
+    if (predicates == null)
+        predicates = {};
 
     // assign fields
     this.initialCanvasId = canvasObj.id;
     this.initialViewportX = viewportX;
     this.initialViewportY = viewportY;
-    this.initialPredicates = predicates;
+    this.initialPredicates = JSON.stringify(predicates);
 }
 
 function sendProjectRequestToBackend(portNumber, projectJSON) {

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -166,10 +166,14 @@ function setInitialStates(canvasObj, viewportX, viewportY, predicates) {
     if (predicates == null) {
         predicates = [];
         for (var i = 0; i < this.canvases[canvasId].layers.length; i ++)
-            predicates.push("");
+            predicates.push({});
     }
     if (predicates.length != this.canvases[canvasId].layers.length)
         throw new Error("Initial canvas: # predicates does not equal # layers.");
+
+    // serialize initial predicates into strings, so that gson (in the backend) can recognize
+    for (var i = 0; i < predicates.length; i ++)
+        predicates[i] = JSON.stringify(predicates[i]);
 
     // assign fields
     this.initialCanvasId = canvasObj.id;

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -69,6 +69,11 @@ function RefreshDynamicLayers(viewportX, viewportY) {
 
     viewportX = +viewportX;
     viewportY = +viewportY;
+
+    // optional rendering args
+    var optionalArgs = getOptionalArgs();
+    optionalArgs["viewportX"] = viewportX;
+    optionalArgs["viewportY"] = viewportY;
     if (param.fetchingScheme == "tiling") {
 
         var tileW = globalVar.tileW;
@@ -165,10 +170,7 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                                     return;
 
                                 // draw current layer
-                                curLayer.rendering.parseFunction()(tileSvg, renderData[i],
-                                    globalVar.curCanvas.w,
-                                    globalVar.curCanvas.h,
-                                    globalVar.renderingParams);
+                                curLayer.rendering.parseFunction()(tileSvg, renderData[i], optionalArgs);
 
                                 tileSvg.transition()
                                     .duration(param.tileEnteringDuration)
@@ -319,10 +321,7 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                     globalVar.renderData[i] = newLayerData;
 
                     // draw current layer
-                    curLayer.rendering.parseFunction()(dboxSvg, renderData[i],
-                        globalVar.curCanvas.w,
-                        globalVar.curCanvas.h,
-                        globalVar.renderingParams);
+                    curLayer.rendering.parseFunction()(dboxSvg, renderData[i], optionalArgs);
 
                     // register jumps
                     if (!globalVar.animation)

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -135,7 +135,7 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                             + "x=" + d[0] + "&"
                             + "y=" + d[1];
                         for (var i = 0; i < globalVar.predicates.length; i ++)
-                            postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
+                            postData += "&predicate" + i + "=" + globalVar.predicates[i];
                         $.post("/tile", postData, function (data, status) {
 
                             // response data
@@ -224,7 +224,7 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                 + "x=" + (viewportX | 0) + "&"
                 + "y=" + (viewportY | 0);
             for (var i = 0; i < globalVar.predicates.length; i ++)
-                postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
+                postData += "&predicate" + i + "=" + globalVar.predicates[i];
             if (param.deltaBox)
                 postData += "&oboxx=" + cBoxX + "&oboxy=" + cBoxY
                     + "&oboxw=" + cBoxW + "&oboxh=" + cBoxH;

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -9,7 +9,7 @@ function renderAxes(viewportX, viewportY, vWidth, vHeight) {
     if (axesFunc == "")
         return ;
 
-    var axes = axesFunc.parseFunction()(globalVar.curCanvas.w, globalVar.curCanvas.h);
+    var axes = axesFunc.parseFunction()(getOptionalArgs());
     for (var i = 0; i < axes.length; i ++) {
         // create g element
         var curg = axesg.append("g")
@@ -135,7 +135,7 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                             + "x=" + d[0] + "&"
                             + "y=" + d[1];
                         for (var i = 0; i < globalVar.predicates.length; i ++)
-                            postData += "&predicate" + i + "=" + globalVar.predicates[i];
+                            postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
                         $.post("/tile", postData, function (data, status) {
 
                             // response data
@@ -224,7 +224,7 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                 + "x=" + (viewportX | 0) + "&"
                 + "y=" + (viewportY | 0);
             for (var i = 0; i < globalVar.predicates.length; i ++)
-                postData += "&predicate" + i + "=" + globalVar.predicates[i];
+                postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
             if (param.deltaBox)
                 postData += "&oboxx=" + cBoxX + "&oboxy=" + cBoxY
                     + "&oboxw=" + cBoxW + "&oboxh=" + cBoxH;

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -142,10 +142,8 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                             var numLayers = globalVar.curCanvas.layers.length;
                             for (var i = 0; i < numLayers; i ++)
                                 renderData[i] = renderData[i].filter(function (d) {
-                                        if (d[d.length - param.maxxOffset] < x ||
-                                            d[d.length - param.minxOffset] > (x + globalVar.tileW) ||
-                                            d[d.length - param.maxyOffset] < y ||
-                                            d[d.length - param.minyOffset] > (y + globalVar.tileH))
+                                        if (+d.maxx < x || +d.minx > (x + globalVar.tileW)
+                                            || +d.maxy < y || +d.miny > (y + globalVar.tileH))
                                             return false;
                                         return true;});
 
@@ -273,10 +271,8 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                         .selectAll("*")
                         .filter(function(d) {
                             if (d == null) return false; // requiring all non-def stuff to be bound to data
-                            if (d[d.length - param.maxxOffset] < x ||
-                                d[d.length - param.minxOffset] > (x + response.boxW) ||
-                                d[d.length - param.maxyOffset] < y ||
-                                d[d.length - param.minyOffset] > (y + response.boxH))
+                            if (+d.maxx < x || +d.minx > (x + response.boxW)
+                                || +d.maxy < y || +d.miny > (y + response.boxH))
                                 return true;
                             else
                                 return false;
@@ -300,10 +296,8 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                         mp[JSON.stringify(d)] = true;
                     });
                     renderData[i] = renderData[i].filter(function (d) {
-                        if (+d[d.length - param.maxxOffset] < x ||
-                            +d[d.length - param.minxOffset] > (x + response.boxW) ||
-                            +d[d.length - param.maxyOffset] < y ||
-                            +d[d.length - param.minyOffset] > (y + response.boxH))
+                        if (+d.maxx < x || +d.minx > (x + response.boxW)
+                            || +d.maxy < y || +d.miny > (y + response.boxH))
                             return false;
                         if (mp.hasOwnProperty(JSON.stringify(d)))
                             return false;
@@ -315,10 +309,8 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                         // add data from intersection w/ old box data
                         for (var j = 0; j < globalVar.renderData[i].length; j ++) {
                             var d = globalVar.renderData[i][j];
-                            if (! (d[d.length - param.maxxOffset] < x ||
-                                    d[d.length - param.minxOffset] > (x + response.boxW) ||
-                                    d[d.length - param.maxyOffset] < y ||
-                                    d[d.length - param.minyOffset] > (y + response.boxH)))
+                            if (! (+d.maxx < x || +d.minx > (x + response.boxW)
+                                    || +d.maxy < y || +d.miny > (y + response.boxH)))
                                 newLayerData.push(d);
                         }
                     }

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -135,7 +135,7 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                             + "x=" + d[0] + "&"
                             + "y=" + d[1];
                         for (var i = 0; i < globalVar.predicates.length; i ++)
-                            postData += "&predicate" + i + "=" + globalVar.predicates[i];
+                            postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
                         $.post("/tile", postData, function (data, status) {
 
                             // response data
@@ -224,7 +224,7 @@ function RefreshDynamicLayers(viewportX, viewportY) {
                 + "x=" + (viewportX | 0) + "&"
                 + "y=" + (viewportY | 0);
             for (var i = 0; i < globalVar.predicates.length; i ++)
-                postData += "&predicate" + i + "=" + globalVar.predicates[i];
+                postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
             if (param.deltaBox)
                 postData += "&oboxx=" + cBoxX + "&oboxy=" + cBoxY
                     + "&oboxw=" + cBoxW + "&oboxh=" + cBoxH;

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -63,36 +63,45 @@ function getTileArray(canvasId, vX, vY, vWidth, vHeight) {
 
 function RefreshDynamicLayers(viewportX, viewportY) {
 
+    // current viewport
+    viewportX = +viewportX;
+    viewportY = +viewportY;
+    var vpW, vpH;
+    if (d3.select(".mainsvg:not(.static)").size() == 0)
+        vpW = globalVar.viewportWidth, vpH = globalVar.viewportHeight;
+    else {
+        var curViewport = d3.select(".mainsvg:not(.static)").attr("viewBox").split(" ");
+        vpW = +curViewport[2];
+        vpH = +curViewport[3];
+    }
+
+    // render axes
+    renderAxes(viewportX, viewportY, vpW, vpH);
+
     // no dynamic layers? return
     if (d3.select(".mainsvg:not(.static)").size() == 0)
         return ;
-
-    viewportX = +viewportX;
-    viewportY = +viewportY;
 
     // optional rendering args
     var optionalArgs = getOptionalArgs();
     optionalArgs["viewportX"] = viewportX;
     optionalArgs["viewportY"] = viewportY;
+
     if (param.fetchingScheme == "tiling") {
 
         var tileW = globalVar.tileW;
         var tileH = globalVar.tileH;
 
         // get tile ids
-        var curViewport = d3.select(".mainsvg:not(.static)").attr("viewBox").split(" ");
         var tileIds = getTileArray(globalVar.curCanvasId,
-            viewportX, viewportY, +curViewport[2], +curViewport[3]);
-
-        // render axes
-        renderAxes(viewportX, viewportY, +curViewport[2], +curViewport[3]);
+            viewportX, viewportY, vpW, vpH);
 
         // set viewport, here we only change min-x and min-y of the viewport.
         // Size of the viewport is set either by pageOnLoad(), animateSemanticZoom() or zoomed()
         // and should not be changed in this function
         d3.selectAll(".mainsvg:not(.static)")
             .attr("viewBox", viewportX + " " + viewportY + " "
-                + curViewport[2]+ " " + curViewport[3])
+                + vpW + " " + vpH)
             .each(function () { // remove invisible tiles
                 var tiles = d3.select(this)
                     .selectAll("svg")
@@ -190,15 +199,6 @@ function RefreshDynamicLayers(viewportX, viewportY) {
             });
     }
     else if (param.fetchingScheme == "dbox") {
-
-        // todo: presumably there should be a request queue to handle concurrent requests
-        // get current viewport
-        var curViewport = d3.select(".mainsvg:not(.static)").attr("viewBox").split(" ");
-        var vpW = +curViewport[2];
-        var vpH = +curViewport[3];
-
-        // render axes
-        renderAxes(viewportX, viewportY, +curViewport[2], +curViewport[3]);
 
         d3.selectAll(".mainsvg:not(.static)")
             .attr("viewBox", viewportX + " " + viewportY + " " + vpW + " " + vpH);

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -213,26 +213,30 @@ function RefreshDynamicLayers(viewportX, viewportY) {
         if (d3.event != null && d3.event.transform.k != 1)
             return ;
 
-        // get new box
-        // send request to backend to get data
-        var postData = "id=" + globalVar.curCanvasId + "&"
-            + "x=" + (viewportX | 0) + "&"
-            + "y=" + (viewportY | 0);
-        for (var i = 0; i < globalVar.predicates.length; i ++)
-            postData += "&predicate" + i + "=" + globalVar.predicates[i];
+        // check if the user has moved outside the current box
         var cBoxX = globalVar.boxX[globalVar.boxX.length - 1], cBoxY = globalVar.boxY[globalVar.boxY.length - 1];
         var cBoxW = globalVar.boxW[globalVar.boxW.length - 1], cBoxH = globalVar.boxH[globalVar.boxH.length - 1];
-        if (param.deltaBox)
-            postData += "&oboxx=" + cBoxX + "&oboxy=" + cBoxY
-                + "&oboxw=" + cBoxW + "&oboxh=" + cBoxH;
-        else
-            postData += "&oboxx=" + (-1e5) + "&oboxy=" + (-1e5)
-                + "&oboxw=" + (-1e5) + "&oboxh=" + (-1e5);
         if (cBoxX < -1e4 || (viewportX <= cBoxX + vpW / 3 && cBoxX >= 0)
             || ((viewportX + vpW) >= (cBoxX + cBoxW) - vpW / 3 && cBoxX + cBoxW <= globalVar.curCanvas.w)
             || (viewportY <= cBoxY + vpH / 3 && cBoxY >= 0)
             || ((viewportY + vpH) >= (cBoxY + cBoxH) - vpH / 3 && cBoxY + cBoxH <= globalVar.curCanvas.h)) {
 
+            // new box request
+            var postData = "id=" + globalVar.curCanvasId + "&"
+                + "x=" + (viewportX | 0) + "&"
+                + "y=" + (viewportY | 0);
+            for (var i = 0; i < globalVar.predicates.length; i ++)
+                postData += "&predicate" + i + "=" + globalVar.predicates[i];
+            if (param.deltaBox)
+                postData += "&oboxx=" + cBoxX + "&oboxy=" + cBoxY
+                    + "&oboxw=" + cBoxW + "&oboxh=" + cBoxH;
+            else
+                postData += "&oboxx=" + (-1e5) + "&oboxy=" + (-1e5)
+                    + "&oboxw=" + (-1e5) + "&oboxh=" + (-1e5);
+            if (globalVar.curCanvas.wSql.length > 0)
+                postData += "&canvasw=" + globalVar.curCanvas.w;
+            if (globalVar.curCanvas.hSql.length > 0)
+                postData += "&canvash=" + globalVar.curCanvas.h;
             globalVar.pendingBoxRequest = true;
             $.post("/dbox", postData, function (data) {
 

--- a/front-end/js/globalVar.js
+++ b/front-end/js/globalVar.js
@@ -76,3 +76,12 @@ function getSqlPredicate(p) {
             + getSqlPredicate(p["OR"][1]) + ")";
     return "";
 }
+
+function getCanvasById(canvasId) {
+
+    for (var i = 0; i < globalVar.project.canvases.length; i ++)
+        if (globalVar.project.canvases[i].id == canvasId)
+            return globalVar.project.canvases[i];
+
+    return null;
+}

--- a/front-end/js/globalVar.js
+++ b/front-end/js/globalVar.js
@@ -51,6 +51,7 @@ if (typeof String.prototype.parseFunction != 'function') {
     };
 }
 
+/******** common functions ********/
 function getOptionalArgs() {
 
     var predicateDict = {};
@@ -61,4 +62,17 @@ function getOptionalArgs() {
         predicates : predicateDict, renderingParams : globalVar.renderingParams};
 
     return optionalArgs;
+}
+
+function getSqlPredicate(p) {
+
+    if ("==" in p)
+        return "(" + p["=="][0] + "=\'" + p["=="][1] + "\')";
+    if ("AND" in p)
+        return "(" + getSqlPredicate(p["AND"][0]) + " AND "
+            + getSqlPredicate(p["AND"][1]) + ")";
+    if ("OR" in p)
+        return "(" + getSqlPredicate(p["OR"][0]) + " OR "
+            + getSqlPredicate(p["OR"][1]) + ")";
+    return "";
 }

--- a/front-end/js/globalVar.js
+++ b/front-end/js/globalVar.js
@@ -50,3 +50,15 @@ if (typeof String.prototype.parseFunction != 'function') {
             return null;
     };
 }
+
+function getOptionalArgs() {
+
+    var predicateDict = {};
+    for (var i = 0; i < globalVar.predicates.length; i ++)
+        predicateDict["layer" + i] = globalVar.predicates[i];
+    var optionalArgs = {canvasW : globalVar.curCanvas.w, canvasH : globalVar.curCanvas.h,
+        viewportW : globalVar.viewportWidth, viewportH : globalVar.viewportHeight,
+        predicates : predicateDict, renderingParams : globalVar.renderingParams};
+
+    return optionalArgs;
+}

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -378,7 +378,7 @@ function registerJumps(svg, layerId) {
                     // prefetch canvas object by sending an async request to server
                     var postData = "id=" + globalVar.curCanvasId;
                     for (var i = 0; i < globalVar.predicates.length; i ++)
-                        postData += "&predicate" + i + "=" + globalVar.predicates[i];
+                        postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
                     if (! (postData in globalVar.cachedCanvases)) {
                         $.ajax({
                             type : "POST",
@@ -409,7 +409,7 @@ function registerJumps(svg, layerId) {
                         // viewport is fixed at a certain tuple
                         var postData = "canvasId=" + globalVar.curCanvasId;
                         for (var i = 0; i < newViewportRet[1].length; i++)
-                            postData += "&predicate" + i + "=" + newViewportRet[1][i];
+                            postData += "&predicate" + i + "=" + getSqlPredicate(newViewportRet[1][i]);
                         $.ajax({
                             type: "POST",
                             url: "viewport",

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -191,7 +191,6 @@ function animateSemanticZoom(tuple, newViewportX, newViewportY) {
 
                         // render
                         RefreshDynamicLayers(newViewportX, newViewportY);
-
                     })
                     .on("end", function () {
 
@@ -373,12 +372,19 @@ function registerJumps(svg, layerId) {
                     globalVar.curCanvasId = jumps[jumpId].destId;
 
                     // calculate new predicates
-                    globalVar.predicates = jumps[jumpId].newPredicates.parseFunction()(tuple, optionalArgs);
+                    var predDict = jumps[jumpId].newPredicates.parseFunction()(tuple, optionalArgs);
+                    var numLayer = getCanvasById(globalVar.curCanvasId).layers.length;
+                    globalVar.predicates = [];
+                    for (var i = 0; i < numLayer; i ++)
+                        if (("layer" + i) in predDict)
+                            globalVar.predicates.push(getSqlPredicate(predDict["layer" + i]));
+                        else
+                            globalVar.predicates.push("");
 
                     // prefetch canvas object by sending an async request to server
                     var postData = "id=" + globalVar.curCanvasId;
                     for (var i = 0; i < globalVar.predicates.length; i ++)
-                        postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
+                        postData += "&predicate" + i + "=" + globalVar.predicates[i];
                     if (! (postData in globalVar.cachedCanvases)) {
                         $.ajax({
                             type : "POST",

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -377,14 +377,14 @@ function registerJumps(svg, layerId) {
                     globalVar.predicates = [];
                     for (var i = 0; i < numLayer; i ++)
                         if (("layer" + i) in predDict)
-                            globalVar.predicates.push(getSqlPredicate(predDict["layer" + i]));
+                            globalVar.predicates.push(predDict["layer" + i]);
                         else
-                            globalVar.predicates.push("");
+                            globalVar.predicates.push({});
 
                     // prefetch canvas object by sending an async request to server
                     var postData = "id=" + globalVar.curCanvasId;
                     for (var i = 0; i < globalVar.predicates.length; i ++)
-                        postData += "&predicate" + i + "=" + globalVar.predicates[i];
+                        postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
                     if (! (postData in globalVar.cachedCanvases)) {
                         $.ajax({
                             type : "POST",

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -275,6 +275,8 @@ function registerJumps(svg, layerId) {
 
     var jumps = globalVar.curJump;
     var shapes = svg.select("g:last-of-type").selectAll("*");
+    var optionalArgs = getOptionalArgs();
+    optionalArgs["layerId"] = layerId;
 
     shapes.each(function(p) {
 
@@ -282,7 +284,7 @@ function registerJumps(svg, layerId) {
         var hasJump = false;
         for (var k = 0; k < jumps.length; k ++)
             if ((jumps[k].type == param.semanticZoom || jumps[k].type == param.geometricSemanticZoom)
-                && jumps[k].selector.parseFunction()(p, layerId)) {
+                && jumps[k].selector.parseFunction()(p, optionalArgs)) {
                 hasJump = true;
                 break;
             }
@@ -343,7 +345,7 @@ function registerJumps(svg, layerId) {
 
                 // check if this jump is applied in this layer
                 if ((jumps[k].type != param.semanticZoom && jumps[k].type != param.geometricSemanticZoom)
-                    || ! jumps[k].selector.parseFunction()(tuple, layerId))
+                    || ! jumps[k].selector.parseFunction()(tuple, optionalArgs))
                     continue;
 
                 // create table cell and append it to #popovercontent
@@ -354,7 +356,7 @@ function registerJumps(svg, layerId) {
                     .datum(tuple)
                     .attr("data-jump-id", k)
                     .html(jumps[k].name.parseFunction() == null ? jumps[k].name
-                        : jumps[k].name.parseFunction()(tuple));
+                        : jumps[k].name.parseFunction()(tuple, optionalArgs));
 
                 // on click
                 jumpOption.on("click", function () {
@@ -374,7 +376,7 @@ function registerJumps(svg, layerId) {
                     globalVar.curCanvasId = jumps[jumpId].destId;
 
                     // calculate new predicates
-                    globalVar.predicates = jumps[jumpId].newPredicates.parseFunction()(tuple);
+                    globalVar.predicates = jumps[jumpId].newPredicates.parseFunction()(tuple, optionalArgs);
 
                     // prefetch canvas object by sending an async request to server
                     var postData = "id=" + globalVar.curCanvasId;
@@ -399,7 +401,7 @@ function registerJumps(svg, layerId) {
 
                     // calculate new viewport
                     var newViewportFunc = jumps[jumpId].newViewports.parseFunction();
-                    var newViewportRet = newViewportFunc(tuple);
+                    var newViewportRet = newViewportFunc(tuple, optionalArgs);
                     if (newViewportRet[0] == 0) {
                         // constant viewport, no predicate
                         var newViewportX = newViewportRet[1];

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -405,17 +405,21 @@ function registerJumps(svg, layerId) {
                     // calculate new viewport
                     var newViewportFunc = jumps[jumpId].newViewports.parseFunction();
                     var newViewportRet = newViewportFunc(tuple, optionalArgs);
-                    if (newViewportRet[0] == 0) {
+                    if ("constant" in newViewportRet) {
                         // constant viewport, no predicate
-                        var newViewportX = newViewportRet[1];
-                        var newViewportY = newViewportRet[2];
+                        var newViewportX = newViewportRet["constant"][0];
+                        var newViewportY = newViewportRet["constant"][1];
                         animateSemanticZoom(tuple, newViewportX, newViewportY);
                     }
-                    else {
+                    else if ("centroid" in newViewportRet) { //TODO: this is not tested
                         // viewport is fixed at a certain tuple
                         var postData = "canvasId=" + globalVar.curCanvasId;
-                        for (var i = 0; i < newViewportRet[1].length; i++)
-                            postData += "&predicate" + i + "=" + getSqlPredicate(newViewportRet[1][i]);
+                        var predDict = newViewportRet["centroid"];
+                        for (var i = 0; i < numLayer; i ++)
+                            if (("layer" + i) in predDict)
+                                postData += "&predicate" + i + "=" + getSqlPredicate(predDict["layer" + i]);
+                            else
+                                postData += "&predicate" + i + "=";
                         $.ajax({
                             type: "POST",
                             url: "viewport",
@@ -430,6 +434,8 @@ function registerJumps(svg, layerId) {
                             async: false
                         });
                     }
+                    else
+                        throw new Error("Unrecognized new viewport function return value.");
                 });
             }
 

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -121,11 +121,8 @@ function animateSemanticZoom(tuple, newViewportX, newViewportY) {
         curViewport = d3.select(".oldmainsvg:not(.static)").attr("viewBox").split(" ");
     for (var i = 0; i < curViewport.length; i ++)
         curViewport[i] = +curViewport[i];
-    var tupleLen = tuple.length;
-    var tupleCX = +tuple[tupleLen - param.cxOffset];
-    var tupleCY = +tuple[tupleLen - param.cyOffset];
-    var tupleWidth = tuple[tupleLen - param.maxxOffset] - tuple[tupleLen - param.minxOffset];
-    var tupleHeight = tuple[tupleLen - param.maxyOffset] - tuple[tupleLen - param.minyOffset];
+    var tupleWidth = +tuple.maxx - tuple.minx;
+    var tupleHeight = +tuple.maxy - tuple.miny;
     var minx, maxx, miny, maxy;
     if (tupleWidth == 0 || tupleHeight == 0) {  // check when placement func does not exist
         minx = globalVar.curCanvas.w;
@@ -145,10 +142,10 @@ function animateSemanticZoom(tuple, newViewportX, newViewportY) {
             });
     }
     else {
-        minx = tupleCX - tupleWidth / 2.0;
-        maxx = tupleCX + tupleWidth / 2.0;
-        miny = tupleCY - tupleHeight / 2.0;
-        maxy = tupleCY + tupleHeight / 2.0;
+        minx = +tuple.cx - tupleWidth / 2.0;
+        maxx = +tuple.cx + tupleWidth / 2.0;
+        miny = +tuple.cy - tupleHeight / 2.0;
+        maxy = +tuple.cy + tupleHeight / 2.0;
     }
 
     // use tuple boundary to calculate start and end views, and log them to the last history object

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -3,7 +3,7 @@ function getCurCanvas() {
 
     var postData = "id=" + globalVar.curCanvasId;
     for (var i = 0; i < globalVar.predicates.length; i ++)
-        postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
+        postData += "&predicate" + i + "=" + globalVar.predicates[i];
 
     // check if cache has it
     if (postData in globalVar.cachedCanvases) {
@@ -97,18 +97,27 @@ function pageOnLoad() {
     // get information about the first canvas to render
     $.post("/first/", {}, function (data) {
         var response = JSON.parse(data);
-        globalVar.initialViewportX = +response.initialViewportX;
-        globalVar.initialViewportY = +response.initialViewportY;
-        globalVar.viewportWidth = +response.viewportWidth;
-        globalVar.viewportHeight = +response.viewportHeight;
-        globalVar.curCanvasId = response.initialCanvasId;
+        globalVar.project = response.project;
+
+        // initial setup
+        globalVar.initialViewportX = globalVar.project.initialViewportX;
+        globalVar.initialViewportY = globalVar.project.initialViewportY;
+        globalVar.viewportWidth = globalVar.project.viewportWidth;
+        globalVar.viewportHeight = globalVar.project.viewportHeight;
+        globalVar.curCanvasId = globalVar.project.initialCanvasId;
         globalVar.tileW = +response.tileW;
         globalVar.tileH = +response.tileH;
-        globalVar.renderingParams = JSON.parse(response.renderingParams);
-        globalVar.predicates = response.initialPredicates.map(
-            function (o) {
-                return JSON.parse(o);
-            });
+        globalVar.renderingParams = JSON.parse(globalVar.project.renderingParams);
+
+        // process initial predicates
+        var predDict = JSON.parse(globalVar.project.initialPredicates);
+        var numLayer = getCanvasById(globalVar.curCanvasId).layers.length;
+        globalVar.predicates = [];
+        for (var i = 0; i < numLayer; i ++)
+            if (("layer" + i) in predDict)
+                globalVar.predicates.push(getSqlPredicate(predDict["layer" + i]));
+            else
+                globalVar.predicates.push("");
 
         // set up global and main svgs
         d3.select("body")

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -3,7 +3,7 @@ function getCurCanvas() {
 
     var postData = "id=" + globalVar.curCanvasId;
     for (var i = 0; i < globalVar.predicates.length; i ++)
-        postData += "&predicate" + i + "=" + globalVar.predicates[i];
+        postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
 
     // check if cache has it
     if (postData in globalVar.cachedCanvases) {
@@ -115,9 +115,9 @@ function pageOnLoad() {
         globalVar.predicates = [];
         for (var i = 0; i < numLayer; i ++)
             if (("layer" + i) in predDict)
-                globalVar.predicates.push(getSqlPredicate(predDict["layer" + i]));
+                globalVar.predicates.push(predDict["layer" + i]);
             else
-                globalVar.predicates.push("");
+                globalVar.predicates.push({});
 
         // set up global and main svgs
         d3.select("body")

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -3,7 +3,7 @@ function getCurCanvas() {
 
     var postData = "id=" + globalVar.curCanvasId;
     for (var i = 0; i < globalVar.predicates.length; i ++)
-        postData += "&predicate" + i + "=" + globalVar.predicates[i];
+        postData += "&predicate" + i + "=" + getSqlPredicate(globalVar.predicates[i]);
 
     // check if cache has it
     if (postData in globalVar.cachedCanvases) {
@@ -95,18 +95,20 @@ function processRenderingParams() {
 function pageOnLoad() {
 
     // get information about the first canvas to render
-    $.post("/first/", {}, function (data, status) {
+    $.post("/first/", {}, function (data) {
         var response = JSON.parse(data);
-        console.log(response);
         globalVar.initialViewportX = +response.initialViewportX;
         globalVar.initialViewportY = +response.initialViewportY;
-        globalVar.predicates = response.initialPredicates;
         globalVar.viewportWidth = +response.viewportWidth;
         globalVar.viewportHeight = +response.viewportHeight;
         globalVar.curCanvasId = response.initialCanvasId;
         globalVar.tileW = +response.tileW;
         globalVar.tileH = +response.tileH;
         globalVar.renderingParams = JSON.parse(response.renderingParams);
+        globalVar.predicates = response.initialPredicates.map(
+            function (o) {
+                return JSON.parse(o);
+            });
 
         // set up global and main svgs
         d3.select("body")

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -1,14 +1,6 @@
 // parameters
 param = {};
 
-// bounding box column offsets
-param.cxOffset = 6;
-param.cyOffset = 5;
-param.maxxOffset = 2;
-param.minxOffset = 4;
-param.maxyOffset = 1;
-param.minyOffset = 3;
-
 // animation durations, delays
 param.enteringDelta = 0.5;
 param.enteringDuration = 1300;

--- a/front-end/js/staticLayers.js
+++ b/front-end/js/staticLayers.js
@@ -17,10 +17,7 @@ function renderStaticLayers() {
         var curSvg = d3.select(".layerg.layer" + i)
             .select("svg")
             .classed("lowestsvg", true);
-        renderFunc(curSvg, globalVar.curStaticData[i],
-            globalVar.viewportWidth,
-            globalVar.viewportHeight,
-            globalVar.renderingParams);
+        renderFunc(curSvg, globalVar.curStaticData[i], getOptionalArgs());
 
         // register jump
         if (! globalVar.animation)

--- a/tile-server/src/main/java/box/BoxandData.java
+++ b/tile-server/src/main/java/box/BoxandData.java
@@ -1,6 +1,9 @@
 package box;
 
+import project.Canvas;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 
 public class BoxandData {
     public Box box;
@@ -10,5 +13,34 @@ public class BoxandData {
 
         this.box = box;
         this.data = data;
+    }
+
+    // Render data used to be stored in a three-dimenson array (layer, row, field).
+    // To enable writing rendering functions using field names,
+    // we convert it to an array of arrays of dictionaries (hashMap in Java)
+    public static ArrayList<ArrayList<HashMap<String, String>>> getDictionaryFromData(ArrayList<ArrayList<ArrayList<String>>> data, Canvas c) {
+
+        ArrayList<ArrayList<HashMap<String, String>>> ret = new ArrayList<>();
+        int numLayers = data.size();
+        for (int i = 0; i < numLayers; i ++) {
+            ret.add(new ArrayList<>());
+            int numRows = data.get(i).size();
+            ArrayList<String> fields = c.getLayers().get(i).getTransform().getColumnNames();
+            int numFields = fields.size();
+            for (int j = 0; j < numRows; j ++) {
+                ArrayList<String> rowArray = data.get(i).get(j);
+                HashMap<String, String> rowDict = new HashMap<>();
+                for (int k = 0; k < numFields; k ++)
+                    rowDict.put(fields.get(k), rowArray.get(k));
+                rowDict.put("cx", rowArray.get(numFields));
+                rowDict.put("cy", rowArray.get(numFields + 1));
+                rowDict.put("minx", rowArray.get(numFields + 2));
+                rowDict.put("miny", rowArray.get(numFields + 3));
+                rowDict.put("maxx", rowArray.get(numFields + 4));
+                rowDict.put("maxy", rowArray.get(numFields + 5));
+                ret.get(i).add(rowDict);
+            }
+        }
+        return ret;
     }
 }

--- a/tile-server/src/main/java/index/Indexer.java
+++ b/tile-server/src/main/java/index/Indexer.java
@@ -13,6 +13,7 @@ import project.Placement;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.io.File;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +21,7 @@ import java.util.Map;
 /**
  * Created by wenbo on 12/30/18.
  */
-public abstract class Indexer {
+public abstract class Indexer implements Serializable {
 
     // abstract methods
     public abstract void createMV(Canvas c, int layerId) throws Exception;
@@ -120,7 +121,7 @@ public abstract class Indexer {
 
             // centroid_x
             if (centroid_x.substring(0, 4).equals("full"))
-                centroid_x_dbl = c.getW() / 2;
+                centroid_x_dbl = 0;
             else if (centroid_x.substring(0, 3).equals("con"))
                 centroid_x_dbl = Double.parseDouble(centroid_x.substring(4));
             else {
@@ -131,7 +132,7 @@ public abstract class Indexer {
 
             // centroid_y
             if (centroid_y.substring(0, 4).equals("full"))
-                centroid_y_dbl = c.getH() / 2;
+                centroid_y_dbl = 0;
             else if (centroid_y.substring(0, 3).equals("con"))
                 centroid_y_dbl = Double.parseDouble(centroid_y.substring(4));
             else {
@@ -142,7 +143,7 @@ public abstract class Indexer {
 
             // width
             if (width_func.substring(0, 4).equals("full"))
-                width_dbl = c.getW();
+                width_dbl = Double.MAX_VALUE;
             else if (width_func.substring(0, 3).equals("con"))
                 width_dbl = Double.parseDouble(width_func.substring(4));
             else {
@@ -153,7 +154,7 @@ public abstract class Indexer {
 
             // height
             if (height_func.substring(0, 4).equals("full"))
-                height_dbl = c.getH();
+                height_dbl = Double.MAX_VALUE;
             else if (height_func.substring(0, 3).equals("con"))
                 height_dbl = Double.parseDouble(height_func.substring(4));
             else {

--- a/tile-server/src/main/java/main/Main.java
+++ b/tile-server/src/main/java/main/Main.java
@@ -98,6 +98,7 @@ public class Main {
             project = gson.fromJson(projectJSON, Project.class);
         } catch (Exception e) {
             System.out.println("Cannot find definition of main project... waiting...");
+            e.printStackTrace();
         }
         DbConnector.commitConnection(Config.databaseName);
     }

--- a/tile-server/src/main/java/main/Main.java
+++ b/tile-server/src/main/java/main/Main.java
@@ -38,7 +38,6 @@ public class Main {
             System.out.println("Main project definition has not been changed since last session. Starting server right away...");
         }
 
-
         //cache
         TileCache.create();
 

--- a/tile-server/src/main/java/project/Canvas.java
+++ b/tile-server/src/main/java/project/Canvas.java
@@ -1,11 +1,12 @@
 package project;
 
+import java.io.*;
 import java.util.ArrayList;
 
 /**
  * Created by wenbo on 1/4/18.
  */
-public class Canvas {
+public class Canvas implements Serializable {
 
     private String id;
     private int w;
@@ -15,6 +16,22 @@ public class Canvas {
     private double zoomOutFactorX, zoomOutFactorY;
     private ArrayList<Layer> layers;
     private String axes;
+
+    // https://stackoverflow.com/questions/64036/how-do-you-make-a-deep-copy-of-an-object-in-java
+    // this method ensures that the canvas objects are not modified by request handlers in anyway
+    // otherwise dynamic canvas size will be a mess
+    public Canvas deepCopy() throws IOException, ClassNotFoundException {
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos);
+        oos.writeObject(this);
+        oos.flush();
+        oos.close();
+        bos.close();
+        byte[] byteData = bos.toByteArray();
+        ByteArrayInputStream bais = new ByteArrayInputStream(byteData);
+        return (Canvas) new ObjectInputStream(bais).readObject();
+    }
 
     public void setW(int w) {
         this.w = w;

--- a/tile-server/src/main/java/project/Layer.java
+++ b/tile-server/src/main/java/project/Layer.java
@@ -2,10 +2,12 @@ package project;
 
 import index.Indexer;
 
+import java.io.Serializable;
+
 /**
  * Created by wenbo on 4/3/18.
  */
-public class Layer {
+public class Layer implements Serializable {
 
     private Transform transform;
     private boolean isStatic;

--- a/tile-server/src/main/java/project/Placement.java
+++ b/tile-server/src/main/java/project/Placement.java
@@ -1,9 +1,11 @@
 package project;
 
+import java.io.Serializable;
+
 /**
  * Created by wenbo on 1/12/18.
  */
-public class Placement {
+public class Placement implements Serializable {
 
     private String centroid_x;
     private String centroid_y;

--- a/tile-server/src/main/java/project/Project.java
+++ b/tile-server/src/main/java/project/Project.java
@@ -25,7 +25,7 @@ public class Project {
     private String initialCanvasId;
     private int initialViewportX;
     private int initialViewportY;
-    private ArrayList<String> initialPredicates;
+    private String initialPredicates;
     private ArrayList<Canvas> canvases;
     private ArrayList<Jump> jumps;
     private String renderingParams;
@@ -54,7 +54,7 @@ public class Project {
         return initialViewportY;
     }
 
-    public ArrayList<String> getInitialPredicates() {
+    public String getInitialPredicates() {
         return initialPredicates;
     }
 

--- a/tile-server/src/main/java/project/Transform.java
+++ b/tile-server/src/main/java/project/Transform.java
@@ -1,11 +1,12 @@
 package project;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
 /**
  * Created by wenbo on 4/3/18.
  */
-public class Transform {
+public class Transform implements Serializable {
 
     private String id;
     private String query;

--- a/tile-server/src/main/java/server/BoxRequestHandler.java
+++ b/tile-server/src/main/java/server/BoxRequestHandler.java
@@ -23,13 +23,11 @@ public class BoxRequestHandler  implements HttpHandler {
 
     // gson builder
     private final Gson gson;
-    private final Project project;
     private MikeBoxGetter boxGetter;
 
     public BoxRequestHandler() {
 
         gson = new GsonBuilder().create();
-        project = Main.getProject();
         boxGetter = new MikeBoxGetter();
 
     }
@@ -71,7 +69,16 @@ public class BoxRequestHandler  implements HttpHandler {
         canvasId = queryMap.get("id");
         minx = Double.valueOf(queryMap.get("x"));
         miny = Double.valueOf(queryMap.get("y"));
-        Canvas c = project.getCanvas(canvasId);
+        Canvas c = null;
+        try {
+            c = Main.getProject().getCanvas(canvasId).deepCopy();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        if (queryMap.containsKey("canvasw"))
+            c.setW(Integer.valueOf(queryMap.get("canvasw")));
+        if (queryMap.containsKey("canvash"))
+            c.setH(Integer.valueOf(queryMap.get("canvash")));
         ArrayList<String> predicates = new ArrayList<>();
         for (int i = 0; i < c.getLayers().size(); i ++)
             predicates.add(queryMap.get("predicate" + i));
@@ -118,7 +125,7 @@ public class BoxRequestHandler  implements HttpHandler {
         String canvasId = queryMap.get("id");
 
         // check whether this canvas exists
-        if (project.getCanvas(canvasId) == null)
+        if (Main.getProject().getCanvas(canvasId) == null)
             return "Canvas " + canvasId + " does not exist!";
 
         // check passed

--- a/tile-server/src/main/java/server/BoxRequestHandler.java
+++ b/tile-server/src/main/java/server/BoxRequestHandler.java
@@ -9,7 +9,6 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import main.Main;
 import project.Canvas;
-import project.Project;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.BufferedReader;
@@ -99,7 +98,7 @@ public class BoxRequestHandler  implements HttpHandler {
 
         //send data and box back
         Map<String, Object> respMap = new HashMap<>();
-        respMap.put("renderData", data.data);
+        respMap.put("renderData", BoxandData.getDictionaryFromData(data.data, c));
         respMap.put("minx", data.box.getMinx());
         respMap.put("miny", data.box.getMiny());
         respMap.put("boxH", data.box.getHight());

--- a/tile-server/src/main/java/server/CanvasRequestHandler.java
+++ b/tile-server/src/main/java/server/CanvasRequestHandler.java
@@ -1,5 +1,6 @@
 package server;
 
+import box.BoxandData;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.sun.net.httpserver.HttpExchange;
@@ -14,7 +15,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,49 +50,49 @@ public class CanvasRequestHandler implements HttpHandler {
         String canvasId = queryMap.get("id");
 
         // get the current canvas
-        Canvas curCanvas = null;
+        Canvas c = null;
         try {
-            curCanvas = Main.getProject().getCanvas(canvasId).deepCopy();
+            c = Main.getProject().getCanvas(canvasId).deepCopy();
         } catch (Exception e) {
             e.printStackTrace();
         }
 
         // list of predicates
         ArrayList<String> predicates = new ArrayList<>();
-        for (int i = 0; i < curCanvas.getLayers().size(); i ++)
+        for (int i = 0; i < c.getLayers().size(); i ++)
             predicates.add(queryMap.get("predicate" + i));
 
         // calculate w or h if they are not pre-determined
-        if (curCanvas.getwSql().length() > 0) {
-            String predicate = queryMap.get("predicate" + curCanvas.getwLayerId());
-            String sql = curCanvas.getwSql() + " and " + predicate;
-            String db = curCanvas.getDbByLayerId(curCanvas.getwLayerId());
+        if (c.getwSql().length() > 0) {
+            String predicate = queryMap.get("predicate" + c.getwLayerId());
+            String sql = c.getwSql() + " and " + predicate;
+            String db = c.getDbByLayerId(c.getwLayerId());
             try {
-                curCanvas.setW(getWidthOrHeightBySql(sql, db));
+                c.setW(getWidthOrHeightBySql(sql, db));
             } catch (Exception e) {}
         }
-        if (curCanvas.gethSql().length() > 0) {
-            String predicate = queryMap.get("predicate" + curCanvas.gethLayerId());
-            String sql = curCanvas.gethSql() + " and " + predicate;
-            String db = curCanvas.getDbByLayerId(curCanvas.gethLayerId());
+        if (c.gethSql().length() > 0) {
+            String predicate = queryMap.get("predicate" + c.gethLayerId());
+            String sql = c.gethSql() + " and " + predicate;
+            String db = c.getDbByLayerId(c.gethLayerId());
             try {
-                curCanvas.setH(getWidthOrHeightBySql(sql, db));
+                c.setH(getWidthOrHeightBySql(sql, db));
             } catch (Exception e) {}
         }
 
         // get static data
         ArrayList<ArrayList<ArrayList<String>>> staticData = null;
         try {
-            staticData = getStaticData(curCanvas, predicates);
+            staticData = getStaticData(c, predicates);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
         // construct the response object
         Map<String, Object> respMap = new HashMap<>();
-        respMap.put("canvas", curCanvas);
+        respMap.put("canvas", c);
         respMap.put("jump", Main.getProject().getJumps(canvasId));
-        respMap.put("staticData", staticData);
+        respMap.put("staticData", BoxandData.getDictionaryFromData(staticData, c));
         String response = gson.toJson(respMap);
 
         // send the response back

--- a/tile-server/src/main/java/server/CanvasRequestHandler.java
+++ b/tile-server/src/main/java/server/CanvasRequestHandler.java
@@ -50,11 +50,11 @@ public class CanvasRequestHandler implements HttpHandler {
         String canvasId = queryMap.get("id");
 
         // get the current canvas
-        Canvas curCanvas = Main.getProject().getCanvas(canvasId);
-        if (curCanvas == null) {
-            // canvas id does not exist and send back a bad request response
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, "canvas " + query + " does not exist.");
-            return ;
+        Canvas curCanvas = null;
+        try {
+            curCanvas = Main.getProject().getCanvas(canvasId).deepCopy();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
 
         // list of predicates

--- a/tile-server/src/main/java/server/FirstRequestHandler.java
+++ b/tile-server/src/main/java/server/FirstRequestHandler.java
@@ -41,15 +41,9 @@ public class FirstRequestHandler implements HttpHandler {
 
         // construct a response map
         Map<String, Object> respMap = new HashMap<>();
-        respMap.put("initialViewportX", project.getInitialViewportX());
-        respMap.put("initialViewportY", project.getInitialViewportY());
-        respMap.put("initialPredicates", project.getInitialPredicates());
-        respMap.put("viewportWidth", project.getViewportWidth());
-        respMap.put("viewportHeight", project.getViewportHeight());
-        respMap.put("initialCanvasId", project.getInitialCanvasId());
+        respMap.put("project", project);
         respMap.put("tileH", Config.tileH);
         respMap.put("tileW", Config.tileW);
-        respMap.put("renderingParams", project.getRenderingParams());
 
         // convert the response to a json object and send it back
         String response = gson.toJson(respMap);

--- a/tile-server/src/main/java/server/ProjectRequestHandler.java
+++ b/tile-server/src/main/java/server/ProjectRequestHandler.java
@@ -95,9 +95,9 @@ public class ProjectRequestHandler implements HttpHandler {
                     matchFound = true;
 
                     // if size is different, recalculate.
-                    if (oldCanvas.getW() != newCanvas.getW())
+                    if (oldCanvas.getwSql().length() == 0 && oldCanvas.getW() != newCanvas.getW())
                         return true;
-                    if (oldCanvas.getH() != newCanvas.getH())
+                    if (oldCanvas.gethSql().length() == 0 && oldCanvas.getH() != newCanvas.getH())
                         return true;
 
                     // if there's different number of layers, re-index is for sure needed

--- a/tile-server/src/main/java/server/ProjectRequestHandler.java
+++ b/tile-server/src/main/java/server/ProjectRequestHandler.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import index.Indexer;
 import main.Config;
 import main.Main;
 import project.Canvas;
@@ -61,8 +62,10 @@ public class ProjectRequestHandler implements HttpHandler {
                 System.out.println("There is diff that requires recomputing indexes. Shutting down server and recomputing...");
                 Server.terminate();
             }
-            else
+            else {
+                Indexer.associateIndexer();
                 System.out.println("The diff does not require recompute. Refresh your web page now!");
+            }
             Main.setProjectClean();
         } catch (Exception e) {
             e.printStackTrace();
@@ -95,9 +98,11 @@ public class ProjectRequestHandler implements HttpHandler {
                     matchFound = true;
 
                     // if size is different, recalculate.
-                    if (oldCanvas.getwSql().length() == 0 && oldCanvas.getW() != newCanvas.getW())
+                    if (oldCanvas.getW() != newCanvas.getW() || ! oldCanvas.getwSql().equals(newCanvas.getwSql())
+                            || ! oldCanvas.getwLayerId().equals(newCanvas.getwLayerId()))
                         return true;
-                    if (oldCanvas.gethSql().length() == 0 && oldCanvas.getH() != newCanvas.getH())
+                    if (oldCanvas.getH() != newCanvas.getH() || ! oldCanvas.gethSql().equals(newCanvas.gethSql())
+                            || ! oldCanvas.gethLayerId().equals(newCanvas.gethLayerId()))
                         return true;
 
                     // if there's different number of layers, re-index is for sure needed

--- a/tile-server/src/main/java/server/TileRequestHandler.java
+++ b/tile-server/src/main/java/server/TileRequestHandler.java
@@ -1,5 +1,6 @@
 package server;
 
+import box.BoxandData;
 import cache.TileCache;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -81,7 +82,7 @@ public class TileRequestHandler implements HttpHandler {
 
         // construct response
         Map<String, Object> respMap = new HashMap<>();
-        respMap.put("renderData", data);
+        respMap.put("renderData", BoxandData.getDictionaryFromData(data, c));
         respMap.put("minx", minx);
         respMap.put("miny", miny);
         response = gson.toJson(respMap);


### PR DESCRIPTION
**Main improvements to the API:**

- Frontend user-defined functions (zoom, rendering, axes, etc) now take as input a dictionary containing useful info such as current canvas width & height, viewport location and size, current predicates, etc. This enables access to these information without having to work with a long argument list. 
- For zoom functions, the input row is now a dictionary (it used to be an array). This way, accessing the fields of the input row can be done using named attributes (e.g. `row.home_team`), instead of using numeric indexes (e.g. `row[6]`). 
- The developer now describes a predicate using an AND/OR expression tree (used to be a SQL predicate). This is based on the complaints of the ugliness of writing SQL predicates such as having to write escaped quotes. For example, a SQL predicate `home_team = row.team_id OR away_team = row.team_id` is now:
    ```javascript
    {"OR" : [
        {"==" : ["home_team", row.team_id]},
        {"==" : ["away_team", row.team_id]}
      ]
    }
    ```
- Predicate functions now return a dictionary mapping layer ids to predicates (used to be an array of predicates). This is useful when there are many layers on a canvas and only a few of them are associated with predicates. 
- Viewport functions now return a dictionary with keys indicating the type of the returned viewport (`constant` or `tuplecenter`). It used to be magic numbers (0 or 1). 





**Bug fixes:**

- Bugs in checking the diffs for canvases with dynamic sizes.
- Axes were not rendered for canvases without dynamic layers. 