### PR TITLE
issue67

### DIFF
--- a/back-end/src/main/java/project/Jump.java
+++ b/back-end/src/main/java/project/Jump.java
@@ -7,7 +7,7 @@ public class Jump {
     private String type;
     private String selector, viewport, predicates, name;
     private String sourceViewId, destViewId;
-    private String noPrefix;
+    private Boolean noPrefix;
 
     public String getSourceId() {
         return sourceId;
@@ -45,7 +45,7 @@ public class Jump {
         return destViewId;
     }
 
-    public String getNoPrefix() {
+    public Boolean getNoPrefix() {
         return noPrefix;
     }
 

--- a/back-end/src/main/java/project/Jump.java
+++ b/back-end/src/main/java/project/Jump.java
@@ -7,6 +7,7 @@ public class Jump {
     private String type;
     private String selector, viewport, predicates, name;
     private String sourceViewId, destViewId;
+    private String noPrefix;
 
     public String getSourceId() {
         return sourceId;
@@ -44,6 +45,10 @@ public class Jump {
         return destViewId;
     }
 
+    public String getNoPrefix() {
+        return noPrefix;
+    }
+
     @Override
     public String toString() {
         return "Jump{"
@@ -73,6 +78,9 @@ public class Jump {
                 + '\''
                 + ", destViewId='"
                 + destViewId
+                + '\''
+                + ", noPrefix='"
+                + noPrefix
                 + '\''
                 + '}';
     }

--- a/compiler/src/Jump.js
+++ b/compiler/src/Jump.js
@@ -53,7 +53,7 @@ function Jump(sourceCanvas, destCanvas, type, optional) {
     this.name = "name" in optional ? optional.name : destCanvas.id;
     this.sourceViewId = "sourceView" in optional ? optional.sourceView.id : "";
     this.destViewId = "destView" in optional ? optional.destView.id : "";
-    this.noPrefix = "noPrefix" in optional ? optional.noPrefix : "";
+    this.noPrefix = "noPrefix" in optional ? optional.noPrefix : false;
 }
 
 // exports

--- a/compiler/src/Jump.js
+++ b/compiler/src/Jump.js
@@ -53,6 +53,7 @@ function Jump(sourceCanvas, destCanvas, type, optional) {
     this.name = "name" in optional ? optional.name : destCanvas.id;
     this.sourceViewId = "sourceView" in optional ? optional.sourceView.id : "";
     this.destViewId = "destView" in optional ? optional.destView.id : "";
+    this.noPrefix = "noPrefix" in optional ? optional.noPrefix : "";
 }
 
 // exports

--- a/docker-scripts/pre-commit
+++ b/docker-scripts/pre-commit
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Formatter for Java
 # From https://github.com/a1exsh/google-java-format-git-pre-commit-hook
-#!/bin/bash
 
 mkdir -p $GIT_DIR/.cache
 if [[ ! -f $GIT_DIR/.cache/google-java-format-1.6-all-deps.jar ]]

--- a/docker-scripts/pre-commit
+++ b/docker-scripts/pre-commit
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Formatter for Java
 # From https://github.com/a1exsh/google-java-format-git-pre-commit-hook
 #!/bin/bash

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -552,6 +552,9 @@ function registerJumps(viewId, svg, layerId) {
                 else if (jumps[k].type == param.highlight)
                     optionText =
                         "<b>HIGHLIGHT in " + jumps[k].destViewId + " VIEW </b>";
+                if (jumps[k].noPrefix == "true") {
+                    optionText = "";
+                }
                 optionText +=
                     jumps[k].name.parseFunction() == null
                         ? jumps[k].name

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -552,7 +552,7 @@ function registerJumps(viewId, svg, layerId) {
                 else if (jumps[k].type == param.highlight)
                     optionText =
                         "<b>HIGHLIGHT in " + jumps[k].destViewId + " VIEW </b>";
-                if (jumps[k].noPrefix == "true") {
+                if (jumps[k].noPrefix == true) {
                     optionText = "";
                 }
                 optionText +=


### PR DESCRIPTION
use an additional key "noPrefix", and set it to "true" in the optional js object in jumps to avoid automatic prefix
nba case example: 
```
p.addJump(
    new Jump(teamLogoCanvas, teamTimelineCanvas, "semantic_zoom", {
        selector: selector,
        viewport: newViewport,
        predicates: newPredicate,
        name: jumpName,
        noPrefix: "true"
    })
);
```

closes #67 