### PR TITLE
Adding load-sql.sh

### DIFF
--- a/compiler/examples/README.md
+++ b/compiler/examples/README.md
@@ -2,8 +2,7 @@
 
 Data for four example application can be found here: [nba](https://www.dropbox.com/s/baqb01thxvfthk5/nba_db_psql.sql?dl=0), [usmap](https://www.dropbox.com/s/youvfap909mk1m3/usmap_db_psql.sql?dl=0), [forest](https://www.dropbox.com/s/39ji04m926lfx5i/forest_db_psql.sql?dl=0) and [flare](https://www.dropbox.com/s/ugr3cx63ul3tt0k/flare_db_psql.sql?dl=0). 
 
-To load data of `app` (can be one of `nba`, `usmap`, `forest` or `flare`) into your Postgres database, run the following:
+To load data of `app` (can be one of `nba`, `usmap`, `forest` or `flare`) into our docker container, run the following under root git directory:
 
-      $ createdb app
-      $ psql app < app.sql
+      $ ./docker-scripts/load-sql.sh app.sql --dbname app
 

--- a/docker-scripts/load-sql.sh
+++ b/docker-scripts/load-sql.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# check input sql file exists
+SQL_FILE="$1"
+shift
+if [ ! -f $SQL_FILE ]; then
+    echo "Input file $SQL_FILE Not found"
+    exit
+fi
+if [ ! ${SQL_FILE: -4} == ".sql" ]; then
+    echo "Not a sql file: $SQL_FILE"
+    exit
+fi
+
+
+# default db name and table name
+x="${SQL_FILE##*/}"
+if [[ $x == $SQL_FILE ]]; then
+    DB_NAME=${SQL_FILE:0:$((${#SQL_FILE} - 4))}
+    # db name is the same name as the sql file
+else
+    x=${SQL_FILE:$((${#SQL_FILE} - ${#x}))}
+    DB_NAME=${x:0:$((${#x} - 4))}
+fi
+
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    case $key in
+        --dbname)
+            DB_NAME="$2"
+            shift
+            shift
+            ;;
+        *)
+            echo "Wrong argument name $key"
+            exit
+            ;;
+    esac
+done
+
+echo 'DB_NAME='$DB_NAME
+
+# create table and drop table
+docker exec -it kyrix_db_1 psql postgresql://postgres:kyrixftw@localhost/postgres -c "CREATE DATABASE ${DB_NAME}";
+
+# copy file to kyrix_db_1
+docker cp $SQL_FILE kyrix_db_1:/$SQL_FILE
+
+# import sql file content into the selected database
+docker exec -it kyrix_db_1 /bin/sh -c "psql postgresql://postgres:kyrixftw@localhost/${DB_NAME} < ${SQL_FILE}"
+
+
+
+


### PR DESCRIPTION
Adding load-sql.sh in docker-scripts to make importing .sql files easier. 
The shell scipt allows inputting data into a new database by 
`./docker-scripts/load-sql.sh SQL_FILE --dbname DBNAME`