### PR TITLE
AutoDD: more advanced contour plots

### DIFF
--- a/back-end/src/main/java/index/AutoDDInMemoryIndexer.java
+++ b/back-end/src/main/java/index/AutoDDInMemoryIndexer.java
@@ -76,7 +76,8 @@ public class AutoDDInMemoryIndexer extends PsqlSpatialIndexer {
         if (autoDD.getRenderingMode().equals("object+clusternum")
                 || autoDD.getRenderingMode().equals("circle only")
                 || autoDD.getRenderingMode().equals("circle+object")
-                || autoDD.getRenderingMode().equals("contour")) {
+                || autoDD.getRenderingMode().equals("contour only")
+                || autoDD.getRenderingMode().equals("contour+object")) {
 
             // a fake bottom level for non-sampled objects
             Rtrees.add(RTree.create());

--- a/compiler/examples/nba_autodd/nba_autodd.js
+++ b/compiler/examples/nba_autodd/nba_autodd.js
@@ -16,21 +16,28 @@ var query =
     "order by agg_rank;";
 
 var autoDD = {
-    query: query,
-    db: "nba",
-    xCol: "home_score",
-    yCol: "away_score",
-    loX: 69,
-    hiX: 149,
-    loY: 69,
-    hiY: 148,
-    //    bboxW: 162,
-    //    bboxH: 132,
-    axis: true,
-    numLevels: 9,
-    roughN: 999,
-    renderingMode: "contour only",
-    rendering: renderers.teamTimelineRendering
+    data: {
+        db: "nba",
+        query: query
+    },
+    x: {
+        col: "home_score",
+        range: [69, 149]
+    },
+    y: {
+        col: "away_score",
+        range: [69, 148]
+    },
+    rendering: {
+        mode: "contour+object",
+        roughN: 999,
+        //axis: true,
+        obj: {
+            renderer: renderers.teamTimelineRendering,
+            bboxW: 162,
+            bboxH: 132
+        }
+    }
 };
 
 p.addAutoDD(new AutoDD(autoDD), {newPyramid: true, newView: true});

--- a/compiler/examples/nba_autodd/nba_autodd.js
+++ b/compiler/examples/nba_autodd/nba_autodd.js
@@ -28,7 +28,7 @@ var autoDD = {
     axis: true,
     numLevels: 9,
     roughN: 999,
-    renderingMode: "contour"
+    renderingMode: "contour only"
     //    rendering: renderers.teamTimelineRendering
 };
 

--- a/compiler/examples/nba_autodd/nba_autodd.js
+++ b/compiler/examples/nba_autodd/nba_autodd.js
@@ -28,8 +28,8 @@ var autoDD = {
     axis: true,
     numLevels: 9,
     roughN: 999,
-    renderingMode: "contour only"
-    //    rendering: renderers.teamTimelineRendering
+    renderingMode: "contour only",
+    rendering: renderers.teamTimelineRendering
 };
 
 p.addAutoDD(new AutoDD(autoDD), {newPyramid: true, newView: true});

--- a/compiler/examples/nba_autodd/nba_autodd.js
+++ b/compiler/examples/nba_autodd/nba_autodd.js
@@ -31,7 +31,8 @@ var autoDD = {
     rendering: {
         mode: "contour+object",
         roughN: 999,
-        //axis: true,
+        axis: true,
+        contourColorScheme: "interpolateBlues",
         obj: {
             renderer: renderers.teamTimelineRendering,
             bboxW: 162,

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -246,7 +246,10 @@ function addAutoDD(autoDD, args) {
 
         // set retainSizeZoom
         curLayer.setRetainSizeZoom(
-            autoDD.renderingMode == "contour" ? false : true
+            autoDD.renderingMode == "contour only" ||
+                autoDD.renderingMode == "contour+object"
+                ? false
+                : true
         );
 
         // dummy placement

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -392,10 +392,13 @@ function getLayerRenderer() {
                 .attr("height", hiddenRectSize)
                 .attr("fill-opacity", 0)
                 .on("mouseover", function(d) {
-                    var svgParent = d3.select(svg.node().parentNode);
-                    objectRenderer(svgParent, [d], args);
-                    var lastG = svgParent.node().childNodes[
-                        svgParent.node().childElementCount - 1
+                    var svgNode;
+                    if ("tileX" in args)
+                        svgNode = d3.select(svg.node().parentNode);
+                    else svgNode = svg;
+                    objectRenderer(svgNode, [d], args);
+                    var lastG = svgNode.node().childNodes[
+                        svgNode.node().childElementCount - 1
                     ];
                     d3.select(lastG)
                         .attr("id", "autodd_tooltip")

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -174,6 +174,10 @@ function AutoDD(args) {
             ? true
             : false;
     this.axis = "axis" in args.rendering ? args.rendering.axis : false;
+    this.contourColorScheme =
+        "contourColorScheme" in args.rendering
+            ? args.rendering.contourColorScheme
+            : "interpolateViridis";
     this.loX = args.x.range != null ? args.x.range[0] : null;
     this.loY = args.y.range != null ? args.y.range[0] : null;
     this.hiX = args.x.range != null ? args.x.range[1] : null;
@@ -321,8 +325,8 @@ function getLayerRenderer() {
                 return d3.range(1e-4, eMax, eMax / 6);
             })(translatedData);
 
-        const color = d3
-            .scaleSequential(d3.interpolateViridis)
+        var color = d3
+            .scaleSequential(d3["REPLACE_ME_contour_colorScheme"])
             .domain([
                 1e-4,
                 (0.04 * roughN) /
@@ -447,6 +451,7 @@ function getLayerRenderer() {
             .replace(/REPLACE_ME_bandwidth/g, this.contourBandwidth)
             .replace(/REPLACE_ME_radius/g, this.bboxH)
             .replace(/REPLACE_ME_roughN/g, this.roughN.toString())
+            .replace(/REPLACE_ME_contour_colorScheme/g, this.contourColorScheme)
             .replace(
                 /REPLACE_ME_this_rendering/g,
                 this.renderingMode == "contour+object"

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -259,6 +259,7 @@ function getLayerRenderer() {
             x = +args.boxX;
             y = +args.boxY;
         }
+        console.log(contourWidth + " " + contourHeight + " " + x + " " + y);
         var translatedData = data.map(d => ({
             x: d.cx - (x - radius),
             y: d.cy - (y - radius),

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -303,38 +303,40 @@ function getLayerRenderer() {
                 "translate(" + (x - radius) + " " + (y - radius) + ")"
             );
 
-        /*        // SVG
-        g.attr("fill", "none")
-            .attr("stroke", "black")
-            .attr("stroke-opacity", 0)
-            .attr("stroke-linejoin", "round")
-            .selectAll("path")
-            .data(contours)
-            .enter()
-            .append("path")
-            .attr("d", d3.geoPath())
-            .style("fill", d => color(d.value));
-*/
-        var canvas = document.createElement("canvas");
-        var ctx = canvas.getContext("2d");
-        (canvas.width = contourWidth), (canvas.height = contourHeight);
-        g.append("foreignObject")
-            .attr("x", 0)
-            .attr("y", 0)
-            .attr("width", contourWidth)
-            .attr("height", contourHeight)
-            .node()
-            .appendChild(canvas);
-        var path = d3.geoPath().context(ctx);
-        for (var i = 0; i < contours.length; i++) {
-            var contour = contours[i];
-            var threshold = contour.value;
-            ctx.beginPath(),
-                (ctx.fillStyle = color(threshold)),
-                path(contour),
-                ctx.fill();
-        }
         var isObjectOnHover = REPLACE_ME_is_object_onhover;
+        if (isObjectOnHover) {
+            g.attr("fill", "none")
+                .attr("stroke", "black")
+                .attr("stroke-opacity", 0)
+                .attr("stroke-linejoin", "round")
+                .selectAll("path")
+                .data(contours)
+                .enter()
+                .append("path")
+                .attr("d", d3.geoPath())
+                .style("fill", d => color(d.value));
+        } else {
+            var canvas = document.createElement("canvas");
+            var ctx = canvas.getContext("2d");
+            (canvas.width = contourWidth), (canvas.height = contourHeight);
+            g.append("foreignObject")
+                .attr("x", 0)
+                .attr("y", 0)
+                .attr("width", contourWidth)
+                .attr("height", contourHeight)
+                .style("overflow", "auto")
+                .node()
+                .appendChild(canvas);
+            var path = d3.geoPath().context(ctx);
+            for (var i = 0; i < contours.length; i++) {
+                var contour = contours[i];
+                var threshold = contour.value;
+                ctx.beginPath(),
+                    (ctx.fillStyle = color(threshold)),
+                    path(contour),
+                    ctx.fill();
+            }
+        }
         if (isObjectOnHover) {
             var objectRenderer = REPLACE_ME_this_rendering;
             var hiddenRectSize = 100;
@@ -349,8 +351,12 @@ function getLayerRenderer() {
                 .attr("height", hiddenRectSize)
                 .attr("fill-opacity", 0)
                 .on("mouseover", function(d) {
-                    objectRenderer(svg, [d], args);
-                    svg.selectAll("g:last-of-type")
+                    var svgParent = d3.select(svg.node().parentNode);
+                    objectRenderer(svgParent, [d], args);
+                    var lastG = svgParent.node().childNodes[
+                        svgParent.node().childElementCount - 1
+                    ];
+                    d3.select(lastG)
                         .attr("id", "autodd_tooltip")
                         .style("opacity", 0.8)
                         .style("pointer-events", "none")

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -47,10 +47,10 @@ param.load = "load";
 param.highlight = "highlight";
 
 // fetching scheme -- either tiling or dbox
-param.fetchingScheme = "tiling";
+param.fetchingScheme = "dbox";
 
 // whether use delta box
-param.deltaBox = true;
+param.deltaBox = false;
 
 // epsilon
 param.eps = 1e-5;

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -50,7 +50,7 @@ param.highlight = "highlight";
 param.fetchingScheme = "dbox";
 
 // whether use delta box
-param.deltaBox = false;
+param.deltaBox = true;
 
 // epsilon
 param.eps = 1e-5;

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -47,7 +47,7 @@ param.load = "load";
 param.highlight = "highlight";
 
 // fetching scheme -- either tiling or dbox
-param.fetchingScheme = "dbox";
+param.fetchingScheme = "tiling";
 
 // whether use delta box
 param.deltaBox = false;

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -47,7 +47,7 @@ param.load = "load";
 param.highlight = "highlight";
 
 // fetching scheme -- either tiling or dbox
-param.fetchingScheme = "tiling";
+param.fetchingScheme = "dbox";
 
 // whether use delta box
 param.deltaBox = false;


### PR DESCRIPTION
- hovering over contour lines to see example objects (see image below)
- HTML canvas for faster and more detailed rendering (however, due to a [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=148499), it's disabled now when hovering to see objects is desired)
- tunable color scheme (in [d3's color scheme](https://github.com/d3/d3-scale-chromatic) syntax)

![image](https://user-images.githubusercontent.com/5410441/61988169-b3c94c00-afeb-11e9-8751-64ad6f31579a.png)
