### PR TITLE
Better literal zooms

### DIFF
--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -54,6 +54,7 @@ function AutoDD(args) {
             throw new Error(
                 "Constructing AutoDD: A rough estimate of total objects (rendering.roughN) is missing for KDE rendering modes."
             );
+        if (!("obj" in args.rendering)) args.rendering.obj = {};
         args.rendering["obj"]["bboxW"] = args.rendering["obj"]["bboxH"] =
             this.contourBandwidth * 8; // as what's implemented by d3-contour
     }

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -179,6 +179,8 @@ function AutoDD(args) {
         "contourColorScheme" in args.rendering
             ? args.rendering.contourColorScheme
             : "interpolateViridis";
+    this.contourOpacity =
+        "contourOpacity" in args.rendering ? args.rendering.contourOpacity : 1;
     this.loX = args.x.range != null ? args.x.range[0] : null;
     this.loY = args.y.range != null ? args.y.range[0] : null;
     this.hiX = args.x.range != null ? args.x.range[1] : null;
@@ -356,7 +358,8 @@ function getLayerRenderer() {
                 .enter()
                 .append("path")
                 .attr("d", d3.geoPath())
-                .style("fill", d => color(d.value));
+                .style("fill", d => color(d.value))
+                .style("opacity", REPLACE_ME_CONTOUR_OPACITY);
         } else {
             var canvas = document.createElement("canvas");
             var ctx = canvas.getContext("2d");
@@ -369,6 +372,7 @@ function getLayerRenderer() {
                 .style("overflow", "auto")
                 .node()
                 .appendChild(canvas);
+            d3.select(canvas).style("opacity", REPLACE_ME_CONTOUR_OPACITY);
             var path = d3.geoPath().context(ctx);
             for (var i = 0; i < contours.length; i++) {
                 var contour = contours[i];
@@ -456,6 +460,7 @@ function getLayerRenderer() {
             .replace(/REPLACE_ME_radius/g, this.bboxH)
             .replace(/REPLACE_ME_roughN/g, this.roughN.toString())
             .replace(/REPLACE_ME_contour_colorScheme/g, this.contourColorScheme)
+            .replace(/REPLACE_ME_CONTOUR_OPACITY/g, this.contourOpacity)
             .replace(
                 /REPLACE_ME_this_rendering/g,
                 this.renderingMode == "contour+object"

--- a/docker-scripts/compile.sh
+++ b/docker-scripts/compile.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 
-# make a user_app directory
-docker exec -it kyrix_kyrix_1 sh -c "mkdir -p /kyrix/compiler/examples/user_app/"
-
-# copy spec into docker
-for entry in "."/*
-do
-    docker cp $entry kyrix_kyrix_1:/kyrix/compiler/examples/user_app/$entry
-done
+# copy everything
+docker cp . kyrix_kyrix_1:/kyrix/compiler/examples/user_app/
 
 # run specs
 docker exec -w /kyrix/compiler/examples/user_app -it kyrix_kyrix_1 sh -c "node $1 $2"

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -134,6 +134,7 @@ function renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs) {
         })
         .enter();
 
+    var numRenderedTiles = 0;
     newTiles.each(function(d) {
         // append tile svgs
         d3.selectAll(viewClass + ".mainsvg:not(.static)")
@@ -213,7 +214,6 @@ function renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs) {
                         renderData[i],
                         optionalArgsWithTileXY
                     );
-
                     tileSvg
                         .transition()
                         .duration(param.tileEnteringDuration)
@@ -235,6 +235,11 @@ function renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs) {
                             });
                     }
                 }
+
+                // remove old layers
+                numRenderedTiles++;
+                if (!gvd.animation && numRenderedTiles == tileIds.length)
+                    d3.selectAll(viewClass + ".oldlayerg").remove();
             }
         });
     });
@@ -431,6 +436,12 @@ function renderDynamicBoxes(
                         renderData[i],
                         optionalArgsWithBoxWHXY
                     );
+
+                    // remove old layers
+                    if (!gvd.animation)
+                        d3.selectAll(
+                            viewClass + ".oldlayerg.layer" + i
+                        ).remove();
 
                     // register jumps
                     if (!gvd.animation) registerJumps(viewId, dboxSvg, i);

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -347,6 +347,7 @@ function renderDynamicBoxes(
                         .selectAll("g")
                         .selectAll("*")
                         .filter(function(d) {
+                            if (!param.deltaBox) return true;
                             if (d == null) return false; // requiring all non-def stuff to be bound to data
                             if (
                                 +d.maxx < x ||

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -515,36 +515,6 @@ function RefreshDynamicLayers(viewId, viewportX, viewportY) {
     optionalArgs["viewportX"] = viewportX;
     optionalArgs["viewportY"] = viewportY;
 
-    // check if there is literal zooming going on
-    // if yes, rescale the objects
-    // do it both here and upon data return
-    if (d3.event != null && d3.event.transform.k != 1) {
-        // rescale only if there is zoom
-        var numLayer = gvd.curCanvas.layers.length;
-        for (var i = 0; i < numLayer; i++) {
-            if (!gvd.curCanvas.layers[i].retainSizeZoom) continue;
-            // check if this is just a pan
-            objectSelection = d3
-                .selectAll(viewClass + ".layerg.layer" + i)
-                .selectAll(".lowestsvg:not(.static)")
-                .selectAll("g")
-                .selectAll("*");
-            if (!objectSelection.empty()) {
-                var transformStr = objectSelection.attr("transform");
-                var match = /.*scale\(([\d.]+), ([\d.]+)\)/g.exec(transformStr);
-                var scaleX = parseFloat(match[1]);
-                var scaleY = parseFloat(match[2]);
-            }
-            if (
-                Math.abs(Math.max(scaleX, scaleY) * d3.event.transform.k - 1) >
-                param.eps
-            )
-                objectSelection.each(function() {
-                    zoomRescale(viewId, this);
-                });
-        }
-    }
-
     // fetch data
     if (param.fetchingScheme == "tiling")
         renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs);

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -238,7 +238,10 @@ function renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs) {
 
                 // remove old layers
                 numRenderedTiles++;
-                if (!gvd.animation && numRenderedTiles == tileIds.length)
+                if (
+                    gvd.animation != param.semanticZoom &&
+                    numRenderedTiles == tileIds.length
+                )
                     d3.selectAll(viewClass + ".oldlayerg").remove();
             }
         });
@@ -437,12 +440,6 @@ function renderDynamicBoxes(
                         optionalArgsWithBoxWHXY
                     );
 
-                    // remove old layers
-                    if (!gvd.animation)
-                        d3.selectAll(
-                            viewClass + ".oldlayerg.layer" + i
-                        ).remove();
-
                     // register jumps
                     if (!gvd.animation) registerJumps(viewId, dboxSvg, i);
 
@@ -459,6 +456,10 @@ function renderDynamicBoxes(
                             });
                     }
                 }
+
+                // remove old layers
+                if (gvd.animation != param.semanticZoom)
+                    d3.selectAll(viewClass + ".oldlayerg").remove();
 
                 // modify global var
                 gvd.boxH.push(response.boxH);
@@ -513,12 +514,6 @@ function RefreshDynamicLayers(viewId, viewportX, viewportY) {
     var optionalArgs = getOptionalArgs(viewId);
     optionalArgs["viewportX"] = viewportX;
     optionalArgs["viewportY"] = viewportY;
-
-    // set viewboxes
-    d3.selectAll(viewClass + ".mainsvg:not(.static)").attr(
-        "viewBox",
-        viewportX + " " + viewportY + " " + vpW + " " + vpH
-    );
 
     // check if there is literal zooming going on
     // if yes, rescale the objects

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -15,7 +15,7 @@ function removePopoversSmooth(viewId) {
 }
 
 // disable and remove stuff before jump
-function preJump(viewId) {
+function preJump(viewId, zoomType) {
     var gvd = globalVar.views[viewId];
     var viewClass = ".view_" + viewId;
 
@@ -44,7 +44,7 @@ function preJump(viewId) {
         .on("click", null);
     d3.selectAll("button" + viewClass).attr("disabled", true);
 
-    gvd.animation = true;
+    gvd.animation = zoomType;
 }
 
 function postJump(viewId, zoomType) {
@@ -121,6 +121,9 @@ function postJump(viewId, zoomType) {
         .style("opacity", 1);
 
     // remove old layers if appropriate
+    for (var i = 0; i < gvd.curCanvas.layers.length; i++)
+        if (gvd.curCanvas.layers[i].isStatic)
+            d3.selectAll(viewClass + ".oldlayerg" + ".layer" + i).remove();
     if (
         !(
             zoomType == param.geometricSemanticZoom ||
@@ -175,10 +178,10 @@ function semanticZoom(viewId, jump, predArray, newVpX, newVpY, tuple) {
     }
 
     // disable stuff before animation
-    preJump(viewId);
+    var zoomType = gvd.history[gvd.history.length - 1].zoomType;
+    preJump(viewId, zoomType);
 
     // whether this semantic zoom is also geometric
-    var zoomType = gvd.history[gvd.history.length - 1].zoomType;
     var enteringAnimation = zoomType == param.semanticZoom ? true : false;
 
     // calculate tuple boundary
@@ -370,7 +373,7 @@ function load(predArray, newVpX, newVpY, jump) {
     gvd.history = [];
 
     // pre animation
-    preJump(destViewId);
+    preJump(destViewId, jump.type);
 
     // draw buttons because they were not created if it was an empty view
     drawZoomButtons(destViewId);
@@ -382,7 +385,7 @@ function load(predArray, newVpX, newVpY, jump) {
         renderStaticLayers(destViewId);
 
         // post animation
-        postJump(destViewId);
+        postJump(destViewId, jump.type);
     });
 }
 

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -120,19 +120,15 @@ function postJump(viewId, zoomType) {
         .duration(param.axesInDuration)
         .style("opacity", 1);
 
-    // use a d3 transition to remove things based on zoom type
-    var removalDelay = 0;
+    // remove old layers if appropriate
     if (
-        zoomType == param.geometricSemanticZoom ||
-        zoomType == param.literalZoomIn ||
-        zoomType == param.literalZoomOut
+        !(
+            zoomType == param.geometricSemanticZoom ||
+            zoomType == param.literalZoomIn ||
+            zoomType == param.literalZoomOut
+        )
     )
-        removalDelay = param.oldRemovalDelay;
-    var numOldLayer = d3.selectAll(viewClass + ".oldlayerg").size();
-    d3.selectAll(viewClass + ".oldlayerg")
-        .transition()
-        .duration(removalDelay)
-        .remove();
+        d3.selectAll(viewClass + ".oldlayerg").remove();
     postOldLayerRemoval();
 }
 

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -65,7 +65,7 @@ function postJump(viewId, zoomType) {
         else setupZoom(viewId, 1);
 
         // set up button states
-        setButtonState(viewId);
+        setBackButtonState(viewId);
 
         // animation stopped now
         gvd.animation = false;

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -30,12 +30,13 @@ function preJump(viewId, zoomType) {
     removePopoversSmooth(viewId);
 
     // change .mainsvg to .oldmainsvg, and .layerg to .oldlayerg
-    d3.selectAll(viewClass + ".mainsvg")
-        .classed("mainsvg", false)
-        .classed("oldmainsvg", true);
     d3.selectAll(viewClass + ".layerg")
         .classed("layerg", false)
         .classed("oldlayerg", true);
+
+    d3.selectAll(viewClass + ".mainsvg")
+        .classed("mainsvg", false)
+        .classed("oldmainsvg", true);
 
     // remove cursor pointers and onclick listeners
     d3.select(viewClass + ".viewsvg")

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -122,15 +122,18 @@ function postJump(viewId, zoomType) {
 
     // use a d3 transition to remove things based on zoom type
     var removalDelay = 0;
-    if (zoomType == param.geometricSemanticZoom)
+    if (
+        zoomType == param.geometricSemanticZoom ||
+        zoomType == param.literalZoomIn ||
+        zoomType == param.literalZoomOut
+    )
         removalDelay = param.oldRemovalDelay;
     var numOldLayer = d3.selectAll(viewClass + ".oldlayerg").size();
     d3.selectAll(viewClass + ".oldlayerg")
         .transition()
         .duration(removalDelay)
-        .remove()
-        .on("end", postOldLayerRemoval);
-    if (numOldLayer == 0) postOldLayerRemoval();
+        .remove();
+    postOldLayerRemoval();
 }
 
 // animate semantic zoom

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -264,7 +264,7 @@ function pageOnLoad(serverAddr) {
                                 setupZoom(viewId, 1);
 
                                 // set button state
-                                setButtonState(viewId);
+                                setBackButtonState(viewId);
                             };
                         })(viewId)
                     );

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -5,7 +5,6 @@ var param = {};
 param.semanticZoomEnteringDelta = 0.5;
 param.semanticZoomEnteringDuration = 1300;
 param.literalZoomDuration = 500;
-param.oldRemovalDelay = 425;
 
 // semantic zoom scale factor
 param.semanticZoomScaleFactor = 4;

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -5,7 +5,7 @@ var param = {};
 param.semanticZoomEnteringDelta = 0.5;
 param.semanticZoomEnteringDuration = 1300;
 param.literalZoomDuration = 500;
-param.oldRemovalDelay = 100;
+param.oldRemovalDelay = 425;
 
 // semantic zoom scale factor
 param.semanticZoomScaleFactor = 4;

--- a/front-end/js/staticLayers.js
+++ b/front-end/js/staticLayers.js
@@ -22,10 +22,6 @@ function renderStaticLayers(viewId) {
         var curSvg = d3.select(viewClass + ".layerg.layer" + i).select("svg");
         renderFunc(curSvg, gvd.curStaticData[i], getOptionalArgs(viewId));
 
-        // remove old layerg
-        if (!gvd.animation)
-            d3.select(viewClass + ".oldlayerg.layer" + i).remove();
-
         // register jump
         if (!gvd.animation) registerJumps(viewId, curSvg, i);
 

--- a/front-end/js/staticLayers.js
+++ b/front-end/js/staticLayers.js
@@ -22,6 +22,10 @@ function renderStaticLayers(viewId) {
         var curSvg = d3.select(viewClass + ".layerg.layer" + i).select("svg");
         renderFunc(curSvg, gvd.curStaticData[i], getOptionalArgs(viewId));
 
+        // remove old layerg
+        if (!gvd.animation)
+            d3.select(viewClass + ".oldlayerg.layer" + i).remove();
+
         // register jump
         if (!gvd.animation) registerJumps(viewId, curSvg, i);
 

--- a/front-end/js/zoom.js
+++ b/front-end/js/zoom.js
@@ -212,7 +212,7 @@ function zoomed(viewId) {
             vHeight / scaleY
     );
 
-    // for old layer groups
+    // set viewboxes old layer groups
     var jumps = gvd.curJump;
     var zoomType =
         gvd.initialScale == 1 ? param.literalZoomOut : param.literalZoomIn;
@@ -291,6 +291,30 @@ function zoomed(viewId) {
             }
         }
     }
+
+    // set literal zoom button state
+    d3.select(viewClass + ".zoominbutton").attr("disabled", true);
+    d3.select(viewClass + ".zoomoutbutton").attr("disabled", true);
+    var jumps = gvd.curJump;
+    for (var i = 0; i < jumps.length; i++)
+        if (jumps[i].type == "literal_zoom_in")
+            d3.select(viewClass + ".zoominbutton")
+                .attr("disabled", null)
+                .on("click", function() {
+                    literalZoomIn(viewId);
+                });
+        else if (jumps[i].type == "literal_zoom_out")
+            d3.select(viewClass + ".zoomoutbutton")
+                .attr("disabled", null)
+                .on("click", function() {
+                    literalZoomOut(viewId);
+                });
+    if (scaleX > 1 || scaleY > 1)
+        d3.select(viewClass + ".zoomoutbutton")
+            .attr("disabled", null)
+            .on("click", function() {
+                literalZoomOut(viewId);
+            });
 
     // get data
     RefreshDynamicLayers(viewId, viewportX, viewportY);

--- a/front-end/js/zoom.js
+++ b/front-end/js/zoom.js
@@ -29,6 +29,10 @@ function setupZoom(viewId, initialScale) {
     var gvd = globalVar.views[viewId];
     var viewClass = ".view_" + viewId;
 
+    // record initial scale, used to determine whether it's
+    // literal zoom in or literal zoom out
+    gvd.initialScale = initialScale;
+
     // calculate maxScale
     gvd.maxScale = Math.max(
         gvd.curCanvas.zoomInFactorX,
@@ -122,7 +126,7 @@ function completeZoom(viewId, zoomType, oldZoomFactorX, oldZoomFactorY) {
     gvd.initialViewportY = curViewport[1] * oldZoomFactorY;
 
     // pre animation
-    preJump(viewId);
+    preJump(viewId, zoomType);
 
     // get the canvas object
     var gotCanvas = getCurCanvas(viewId);
@@ -199,14 +203,18 @@ function zoomed(viewId) {
     curViewport[3] = vHeight / scaleY;
     d3.selectAll(viewClass + ".mainsvg:not(.static)").attr(
         "viewBox",
-        curViewport[0] +
+        viewportX +
             " " +
-            curViewport[1] +
+            viewportY +
             " " +
             curViewport[2] +
             " " +
             curViewport[3]
     );
+
+    // for old layer groups
+    if (!d3.selectAll(viewClass + ".oldmainsvg:not(.static)").empty()) {
+    }
 
     // get data
     RefreshDynamicLayers(viewId, viewportX, viewportY);
@@ -216,7 +224,7 @@ function zoomed(viewId) {
         (zoomInFactorX > 1 && scaleX >= gvd.maxScale) ||
         (zoomInFactorY > 1 && scaleY >= gvd.maxScale)
     )
-        completeZoom(viewId, "literal_zoom_in", zoomInFactorX, zoomInFactorY);
+        completeZoom(viewId, param.literalZoomIn, zoomInFactorX, zoomInFactorY);
 
     // check if zoom scale reaches zoomOutFactor
     if (
@@ -225,7 +233,7 @@ function zoomed(viewId) {
     )
         completeZoom(
             viewId,
-            "literal_zoom_out",
+            param.literalZoomOut,
             zoomOutFactorX,
             zoomOutFactorY
         );

--- a/front-end/js/zoom.js
+++ b/front-end/js/zoom.js
@@ -214,6 +214,35 @@ function zoomed(viewId) {
 
     // for old layer groups
     if (!d3.selectAll(viewClass + ".oldmainsvg:not(.static)").empty()) {
+        //TODO: this won't work with geometric_semantic_zoom
+        var oldViewportX =
+            viewportX *
+            (gvd.initialScale == 1 ? zoomOutFactorX : zoomInFactorX);
+        var oldViewportY =
+            viewportY *
+            (gvd.initialScale == 1 ? zoomOutFactorY : zoomInFactorY);
+        var oldViewportW =
+            vWidth /
+            (scaleX *
+                (gvd.initialScale == 1
+                    ? 1 / zoomOutFactorX
+                    : 1 / zoomInFactorX));
+        var oldViewportH =
+            vHeight /
+            (scaleY *
+                (gvd.initialScale == 1
+                    ? 1 / zoomOutFactorY
+                    : 1 / zoomInFactorY));
+        d3.selectAll(viewClass + ".oldmainsvg:not(.static)").attr(
+            "viewBox",
+            oldViewportX +
+                " " +
+                oldViewportY +
+                " " +
+                oldViewportW +
+                " " +
+                oldViewportH
+        );
     }
 
     // get data

--- a/front-end/js/zoomButton.js
+++ b/front-end/js/zoomButton.js
@@ -56,7 +56,7 @@ function drawZoomButtons(viewId) {
 }
 
 // called after a new canvas is completely rendered
-function setButtonState(viewId) {
+function setBackButtonState(viewId) {
     var gvd = globalVar.views[viewId];
     var viewClass = ".view_" + viewId;
 
@@ -68,24 +68,6 @@ function setButtonState(viewId) {
                 backspace(viewId);
             });
     else d3.select(viewClass + ".gobackbutton").attr("disabled", true);
-
-    // literal zoom buttons
-    d3.select(viewClass + ".zoominbutton").attr("disabled", true);
-    d3.select(viewClass + ".zoomoutbutton").attr("disabled", true);
-    var jumps = gvd.curJump;
-    for (var i = 0; i < jumps.length; i++)
-        if (jumps[i].type == "literal_zoom_in")
-            d3.select(viewClass + ".zoominbutton")
-                .attr("disabled", null)
-                .on("click", function() {
-                    literalZoomIn(viewId);
-                });
-        else if (jumps[i].type == "literal_zoom_out")
-            d3.select(viewClass + ".zoomoutbutton")
-                .attr("disabled", null)
-                .on("click", function() {
-                    literalZoomOut(viewId);
-                });
 }
 
 // called in completeZoom() and RegisterJump()

--- a/front-end/js/zoomButton.js
+++ b/front-end/js/zoomButton.js
@@ -131,7 +131,7 @@ function backspace(viewId) {
     var fadingAnimation = zoomType == param.semanticZoom ? true : false;
 
     // disable and remove stuff
-    preJump(viewId);
+    preJump(viewId, zoomType);
 
     // assign back global vars
     gvd.curCanvasId = curHistory.canvasId;
@@ -162,10 +162,9 @@ function backspace(viewId) {
             })
             .on("start", startZoomingBack);
     else {
-        d3.selectAll(viewClass + ".oldlayerg")
-            .transition()
-            .delay(param.oldRemovalDelay)
-            .remove();
+        for (var i = 0; i < gvd.curCanvas.layers.length; i++)
+            if (gvd.curCanvas.layers[i].isStatic)
+                d3.selectAll(viewClass + ".oldlayerg" + ".layer" + i).remove();
         startZoomingBack();
     }
 
@@ -209,7 +208,7 @@ function backspace(viewId) {
                 );
             })
             .on("end", function() {
-                postJump(viewId);
+                postJump(viewId, zoomType);
             });
     }
 


### PR DESCRIPTION
The main goal of this PR is to avoid flickering when switching from one canvas to another using `literalZoom` or `geometricSemanticZoom`. 

The trick is to keep the old canvas around until the new canvas rendered (i.e. remove old canvas after the new renderer is called). Before the new canvas is fully rendered, scale and rescale the old canvas as needed. Note that SVG images are rendered asynchronously, so for large images this PR is not sufficient. In the future, this should be fixed. 

<br/>
<br/>

**Before**:
![Alt Text](https://media.giphy.com/media/JsPRvbnOMYod8CVWAM/giphy.gif)

<br/>
<br/>

**After**:
![Alt Text](https://media.giphy.com/media/ckGpCeMksmCOJNV73W/giphy.gif)

<br/>
<br/>

Some other misc fixes:
- fixes #98 
- corrected literal zoom button state controls (updated on zoom, rather than on jump)
- faster `compile.sh` (one `docker cp` for the entire folder, rather than one for each file)
- allow specifying opacity for contours
- allow `obj` in autodd to be omitted

