### PR TITLE
indexer designation

### DIFF
--- a/back-end/src/main/java/box/BoxandData.java
+++ b/back-end/src/main/java/box/BoxandData.java
@@ -37,7 +37,7 @@ public class BoxandData {
                 for (int k = 0; k < numFields; k++) rowDict.put(fields.get(k), rowArray.get(k));
 
                 // cluster number field for autodd layer
-                if (curLayer.isAutoDDLayer()) {
+                if (curLayer.getIndexerType().equals("AutoDDInMemoryIndexer")) {
                     rowDict.put("cluster_num", rowArray.get(numFields));
                     numFields++;
                 }

--- a/back-end/src/main/java/index/Indexer.java
+++ b/back-end/src/main/java/index/Indexer.java
@@ -38,12 +38,15 @@ public abstract class Indexer implements Serializable {
     public static void associateIndexer() throws Exception {
         for (Canvas c : Main.getProject().getCanvases())
             for (int layerId = 0; layerId < c.getLayers().size(); layerId++) {
+
+                // note that if the indexer type is set in the compiler
+                // it overrides the settings in Config.java (or config.yaml in the future)
                 Layer l = c.getLayers().get(layerId);
                 String indexerType = l.getIndexerType();
                 // if the indexerType is empty or wrong, indexer will be null
                 Indexer indexer = getIndexerByType(indexerType);
 
-                // determine indexer for this layer
+                // determine indexer for this layer when the indexer is not set in the compiler
                 if (indexer == null) {
                     if (Config.database == Config.Database.PSQL
                             || Config.database == Config.Database.CITUS) {
@@ -90,7 +93,7 @@ public abstract class Indexer implements Serializable {
             }
     }
 
-    public static Indexer getIndexerByType(String type) {
+    public static Indexer getIndexerByType(String type) throws Exception {
         try {
             Class c = Class.forName("index." + type);
             Method m = c.getMethod("getInstance");
@@ -98,8 +101,6 @@ public abstract class Indexer implements Serializable {
             return (Indexer) m.invoke(null);
         } catch (ClassNotFoundException e) {
             System.out.println("Indexer type not found. default setting will be used");
-        } catch (Exception e) {
-            System.out.println("getIndexerByType: Exception. default setting will be used");
         }
         return null;
     }

--- a/back-end/src/main/java/index/Indexer.java
+++ b/back-end/src/main/java/index/Indexer.java
@@ -94,15 +94,11 @@ public abstract class Indexer implements Serializable {
     }
 
     public static Indexer getIndexerByType(String type) throws Exception {
-        try {
-            Class c = Class.forName("index." + type);
-            Method m = c.getMethod("getInstance");
-            System.out.println("Indexer type: " + c.getSimpleName());
-            return (Indexer) m.invoke(null);
-        } catch (ClassNotFoundException e) {
-            System.out.println("Indexer type not found. default setting will be used");
-        }
-        return null;
+        if (type.isEmpty()) return null;
+        Class c = Class.forName("index." + type);
+        Method m = c.getMethod("getInstance");
+        System.out.println("Indexer type: " + c.getSimpleName());
+        return (Indexer) m.invoke(null);
     }
 
     // precompute

--- a/back-end/src/main/java/index/Indexer.java
+++ b/back-end/src/main/java/index/Indexer.java
@@ -94,12 +94,12 @@ public abstract class Indexer implements Serializable {
         try {
             Class c = Class.forName("index." + type);
             Method m = c.getMethod("getInstance");
+            System.out.println("Indexer type: " + c.getSimpleName());
             return (Indexer) m.invoke(null);
         } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            System.out.println("Indexer type not found");
+            System.out.println("Indexer type not found. default setting will be used");
         } catch (Exception e) {
-            e.printStackTrace();
+            System.out.println("getIndexerByType: Exception. default setting will be used");
         }
         return null;
     }

--- a/back-end/src/main/java/project/Layer.java
+++ b/back-end/src/main/java/project/Layer.java
@@ -1,6 +1,5 @@
 package project;
 
-import com.google.gson.annotations.SerializedName;
 import index.Indexer;
 import java.io.Serializable;
 import third_party.Exclude;
@@ -16,20 +15,6 @@ public class Layer implements Serializable {
     private String rendering;
     @Exclude private Indexer indexer;
     private String autoDDId;
-
-    /*
-    @ SerializedName is an annotation used in gson
-    so that the json fieldname does not have to be the exact same string as in the Java Class.
-    Usage:
-    1. Simple version: @SerializedName("jsonfield") private String javafield;
-    2. More capable version: @SerializedName(value="jsondefault", alternate={"jsonalt1", "jsonalt2"});
-    Note that SerializedName will cover the original field
-    more information can be found at:
-    https://static.javadoc.io/com.google.code.gson/gson/2.6.2/com/google/gson/annotations/SerializedName.html
-    */
-    @SerializedName(
-            value = "indexerClass",
-            alternate = {"indexerType", "indexerName"})
     private String indexerType;
 
     public Transform getTransform() {

--- a/back-end/src/main/java/project/Layer.java
+++ b/back-end/src/main/java/project/Layer.java
@@ -15,9 +15,7 @@ public class Layer implements Serializable {
     private Placement placement;
     private String rendering;
     @Exclude private Indexer indexer;
-    private boolean isAutoDDLayer;
     private String autoDDId;
-    private boolean isPredicatedTable;
 
     @SerializedName(
             value = "indexerClass",
@@ -56,16 +54,8 @@ public class Layer implements Serializable {
         return indexer;
     }
 
-    public boolean isAutoDDLayer() {
-        return isAutoDDLayer;
-    }
-
     public String getAutoDDId() {
         return autoDDId;
-    }
-
-    public boolean isPredicatedTable() {
-        return isPredicatedTable;
     }
 
     public void setIndexerType(String indexerType) {
@@ -81,7 +71,7 @@ public class Layer implements Serializable {
         String colListStr = "";
         for (String col : transform.getColumnNames())
             colListStr += (tableName.isEmpty() ? "" : tableName + ".") + col + ", ";
-        if (isAutoDDLayer) colListStr += "cluster_num, ";
+        if (this.getIndexerType().equals("AutoDDInMemoryIndexer")) colListStr += "cluster_num, ";
         colListStr += "cx, cy, minx, miny, maxx, maxy";
         return colListStr;
     }
@@ -102,8 +92,6 @@ public class Layer implements Serializable {
                 + ", rendering='"
                 + rendering
                 + '\''
-                + ", isAutoDDLayer="
-                + isAutoDDLayer
                 + ", autoDDId="
                 + autoDDId
                 + '}';

--- a/back-end/src/main/java/project/Layer.java
+++ b/back-end/src/main/java/project/Layer.java
@@ -1,7 +1,9 @@
 package project;
 
+import com.google.gson.annotations.SerializedName;
 import index.Indexer;
 import java.io.Serializable;
+import third_party.Exclude;
 
 /** Created by wenbo on 4/3/18. */
 public class Layer implements Serializable {
@@ -12,10 +14,15 @@ public class Layer implements Serializable {
     private boolean deltaBox;
     private Placement placement;
     private String rendering;
-    private Indexer indexer;
+    @Exclude private Indexer indexer;
     private boolean isAutoDDLayer;
     private String autoDDId;
     private boolean isPredicatedTable;
+
+    @SerializedName(
+            value = "indexerClass",
+            alternate = {"indexerType", "indexerName"})
+    private String indexerType;
 
     public Transform getTransform() {
         return transform;
@@ -59,6 +66,14 @@ public class Layer implements Serializable {
 
     public boolean isPredicatedTable() {
         return isPredicatedTable;
+    }
+
+    public void setIndexerType(String indexerType) {
+        this.indexerType = indexerType;
+    }
+
+    public String getIndexerType() {
+        return indexerType;
     }
 
     public String getColStr(String tableName) {

--- a/back-end/src/main/java/project/Layer.java
+++ b/back-end/src/main/java/project/Layer.java
@@ -17,6 +17,16 @@ public class Layer implements Serializable {
     @Exclude private Indexer indexer;
     private String autoDDId;
 
+    /*
+    @ SerializedName is an annotation used in gson
+    so that the json fieldname does not have to be the exact same string as in the Java Class.
+    Usage:
+    1. Simple version: @SerializedName("jsonfield") private String javafield;
+    2. More capable version: @SerializedName(value="jsondefault", alternate={"jsonalt1", "jsonalt2"});
+    Note that SerializedName will cover the original field
+    more information can be found at:
+    https://static.javadoc.io/com.google.code.gson/gson/2.6.2/com/google/gson/annotations/SerializedName.html
+    */
     @SerializedName(
             value = "indexerClass",
             alternate = {"indexerType", "indexerName"})

--- a/back-end/src/main/java/server/FirstRequestHandler.java
+++ b/back-end/src/main/java/server/FirstRequestHandler.java
@@ -11,6 +11,7 @@ import javax.net.ssl.HttpsURLConnection;
 import main.Config;
 import main.Main;
 import project.Project;
+import third_party.AnnotationExclusionStrategy;
 
 /** Created by wenbo on 1/2/18. */
 public class FirstRequestHandler implements HttpHandler {
@@ -19,7 +20,10 @@ public class FirstRequestHandler implements HttpHandler {
     private final Gson gson;
 
     public FirstRequestHandler() {
-        gson = new GsonBuilder().create();
+        gson =
+                new GsonBuilder()
+                        .addSerializationExclusionStrategy(new AnnotationExclusionStrategy())
+                        .create();
     }
 
     @Override

--- a/back-end/src/main/java/third_party/AnnotationExclusionStrategy.java
+++ b/back-end/src/main/java/third_party/AnnotationExclusionStrategy.java
@@ -1,0 +1,17 @@
+package third_party;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+public class AnnotationExclusionStrategy implements ExclusionStrategy {
+
+    @Override
+    public boolean shouldSkipField(FieldAttributes f) {
+        return f.getAnnotation(Exclude.class) != null;
+    }
+
+    @Override
+    public boolean shouldSkipClass(Class<?> clazz) {
+        return false;
+    }
+}

--- a/back-end/src/main/java/third_party/Exclude.java
+++ b/back-end/src/main/java/third_party/Exclude.java
@@ -1,0 +1,10 @@
+package third_party;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Exclude {}

--- a/compiler/src/Layer.js
+++ b/compiler/src/Layer.js
@@ -20,6 +20,7 @@ function Layer(transform, isStatic) {
     else this.isStatic = isStatic;
     this.fetchingScheme = "dbox";
     this.deltaBox = true;
+    this.indexerType = "";
     this.isAutoDDLayer = false;
     this.isPredicatedTable = false;
 }
@@ -96,6 +97,18 @@ function setIsPredicatedTable(isPredicatedTable) {
     this.isPredicatedTable = isPredicatedTable;
 }
 
+/**
+ * set indexer, which tells the backend that which indexer this layer should use
+ * @param indexer
+ */
+function setIndexerType(indexerType) {
+    if (typeof indexerType !== "string") {
+        console.log("the type of an indexer must be a string!");
+        return;
+    }
+    this.indexerType = indexerType;
+}
+
 // define prototype
 Layer.prototype = {
     addPlacement,
@@ -103,7 +116,8 @@ Layer.prototype = {
     setFetchingScheme,
     setIsAutoDD,
     setAutoDDId,
-    setIsPredicatedTable
+    setIsPredicatedTable,
+    setIndexerType
 };
 
 // exports

--- a/compiler/src/Layer.js
+++ b/compiler/src/Layer.js
@@ -84,10 +84,8 @@ function setAutoDDId(autoDDId) {
  * @param indexer
  */
 function setIndexerType(indexerType) {
-    if (typeof indexerType !== "string") {
-        console.log("the type of an indexer must be a string!");
-        return;
-    }
+    if (typeof indexerType !== "string")
+        throw new Error("the type of an indexer must be a string!");
     this.indexerType = indexerType;
 }
 

--- a/compiler/src/Layer.js
+++ b/compiler/src/Layer.js
@@ -85,7 +85,9 @@ function setAutoDDId(autoDDId) {
  */
 function setIndexerType(indexerType) {
     if (typeof indexerType !== "string")
-        throw new Error("the type of an indexer must be a string!");
+        throw new Error(
+            "Constructing Layer: the type of an indexer must be a string!"
+        );
     this.indexerType = indexerType;
 }
 

--- a/compiler/src/Layer.js
+++ b/compiler/src/Layer.js
@@ -21,8 +21,6 @@ function Layer(transform, isStatic) {
     this.fetchingScheme = "dbox";
     this.deltaBox = true;
     this.indexerType = "";
-    this.isAutoDDLayer = false;
-    this.isPredicatedTable = false;
 }
 
 /**
@@ -74,27 +72,11 @@ function setFetchingScheme(fetchingScheme, deltaBox) {
 }
 
 /**
- * set isAutoDD, which tells the backend that this layer should use the autodd indexer
- * @param isAutoDD
- */
-function setIsAutoDD(isAutoDD) {
-    this.isAutoDDLayer = isAutoDD;
-}
-
-/**
  * set autoDD ID
  * @param autoDDId
  */
 function setAutoDDId(autoDDId) {
     this.autoDDId = autoDDId;
-}
-
-/**
- * set isPredicatedTable, which tells the backend that this layer should use the pred table indexer
- * @param isPredicatedTable
- */
-function setIsPredicatedTable(isPredicatedTable) {
-    this.isPredicatedTable = isPredicatedTable;
 }
 
 /**
@@ -114,9 +96,7 @@ Layer.prototype = {
     addPlacement,
     addRenderingFunc,
     setFetchingScheme,
-    setIsAutoDD,
     setAutoDDId,
-    setIsPredicatedTable,
     setIndexerType
 };
 

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -312,7 +312,7 @@ function addAutoDD(autoDD, args) {
             curLayer.setFetchingScheme("dbox", false);
 
         // set isAutoDD and autoDD ID
-        curLayer.setIsAutoDD(true);
+        curLayer.setIndexerType("AutoDDInMemoryIndexer");
         curLayer.setAutoDDId(this.autoDDs.length - 1 + "_" + i);
 
         // dummy placement

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -230,7 +230,7 @@ function addTable(table, args) {
     tableLayer.addPlacement(table.placement);
     tableLayer.addRenderingFunc(table.getTableRenderer());
     if (table.group_by.length > 0) {
-        tableLayer.setIsPredicatedTable(true);
+        tableLayer.setIndexerType("PsqlPredicatedTableIndexer");
     }
     canvas.addLayer(tableLayer);
 


### PR DESCRIPTION
# Indexer designation by class name

fixes #113 

In the compiler, usage like `layer.setIndexerType("PsqlPredicatedTableIndexer")` can be used to designate specific indexer for any layer. Backward compatibility is maintained.

I gave up using `indexer` as fieldname in the compiler because the keyword `transient` will cause the `getIndexer` method which is used in `boxGetter` to return `null`. I have no idea why this would happen.

Alternatively I introduced the `third_party` package and the `Exclude` annotation (see [here](https://stackoverflow.com/questions/4802887/gson-how-to-exclude-specific-fields-from-serialization-without-annotations/27986860#27986860) for more information) to exclude fields during serialization as my discussion with @tracyhenry. I applied this for the `FirstRequestHandler`, but I'm not sure if it is the only place where this annotation is needed.

I tesed the indexer designation on the predicated table example.

Welcome to comment, discuss, criticise.

 

