### PR TITLE
Clearing the cache when loading a new project

### DIFF
--- a/back-end/src/main/java/cache/TileCache.java
+++ b/back-end/src/main/java/cache/TileCache.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import main.Config;
+import main.Main;
 import project.Canvas;
 import project.Layer;
-import main.Main;
 
 public class TileCache {
     private static LinkedHashMap tileCache;
@@ -22,15 +22,15 @@ public class TileCache {
                     }
                 };
     }
-    public static void clear()
-    {
+
+    public static void clear() {
         tileCache.clear();
     }
 
     public static ArrayList<ArrayList<ArrayList<String>>> getTile(
             Canvas c, int minx, int miny, ArrayList<String> predicates) throws Exception {
         String projectName = Main.getProject().getName();
-        String key = projectName + '-' + c + "-" + minx + "-" + miny + "-" + predicates;
+        String key = projectName + '-' + c.getId() + "-" + minx + "-" + miny + "-" + predicates;
         ArrayList<ArrayList<ArrayList<String>>> data = new ArrayList<>();
 
         // cache hit

--- a/back-end/src/main/java/cache/TileCache.java
+++ b/back-end/src/main/java/cache/TileCache.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import main.Config;
 import project.Canvas;
 import project.Layer;
+import main.Main;
 
 public class TileCache {
     private static LinkedHashMap tileCache;
@@ -21,11 +22,15 @@ public class TileCache {
                     }
                 };
     }
+    public static void clear()
+    {
+        tileCache.clear();
+    }
 
     public static ArrayList<ArrayList<ArrayList<String>>> getTile(
             Canvas c, int minx, int miny, ArrayList<String> predicates) throws Exception {
-
-        String key = c + "-" + minx + "-" + miny + "-" + predicates;
+        String projectName = Main.getProject().getName();
+        String key = projectName + '-' + c + "-" + minx + "-" + miny + "-" + predicates;
         ArrayList<ArrayList<ArrayList<String>>> data = new ArrayList<>();
 
         // cache hit

--- a/back-end/src/main/java/main/Main.java
+++ b/back-end/src/main/java/main/Main.java
@@ -41,6 +41,8 @@ public class Main {
 
         System.out.println("Current project set to: " + newProject.getName());
         project = newProject;
+
+        // clear cache whenever there is a project switch
         TileCache.clear();
     }
 

--- a/back-end/src/main/java/main/Main.java
+++ b/back-end/src/main/java/main/Main.java
@@ -41,6 +41,7 @@ public class Main {
 
         System.out.println("Current project set to: " + newProject.getName());
         project = newProject;
+        TileCache.clear();
     }
 
     public static void setProjectClean() throws SQLException, ClassNotFoundException {

--- a/back-end/src/main/java/server/ProjectRequestHandler.java
+++ b/back-end/src/main/java/server/ProjectRequestHandler.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import javax.net.ssl.HttpsURLConnection;
 import main.Main;
 import project.*;
-import cache.TileCache;
 
 /** Created by wenbo on 7/12/18. */
 public class ProjectRequestHandler implements HttpHandler {
@@ -78,7 +77,6 @@ public class ProjectRequestHandler implements HttpHandler {
             if (forceRecompute) {
                 System.out.println(
                         "Requesting force-recompute, ignoring diff, shutting down server and recomputing...");
-                TileCache.clear();
                 Server.terminate();
             } else if (skipRecompute) {
                 System.out.println(
@@ -88,7 +86,6 @@ public class ProjectRequestHandler implements HttpHandler {
             } else if (needsReIndex(oldProject, newProject)) {
                 System.out.println(
                         "There is diff that requires recomputing indexes. Shutting down server and recomputing...");
-                TileCache.clear();
                 Server.terminate();
             } else {
                 System.out.println(

--- a/back-end/src/main/java/server/ProjectRequestHandler.java
+++ b/back-end/src/main/java/server/ProjectRequestHandler.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import javax.net.ssl.HttpsURLConnection;
 import main.Main;
 import project.*;
+import cache.TileCache;
 
 /** Created by wenbo on 7/12/18. */
 public class ProjectRequestHandler implements HttpHandler {
@@ -77,6 +78,7 @@ public class ProjectRequestHandler implements HttpHandler {
             if (forceRecompute) {
                 System.out.println(
                         "Requesting force-recompute, ignoring diff, shutting down server and recomputing...");
+                TileCache.clear();
                 Server.terminate();
             } else if (skipRecompute) {
                 System.out.println(
@@ -86,6 +88,7 @@ public class ProjectRequestHandler implements HttpHandler {
             } else if (needsReIndex(oldProject, newProject)) {
                 System.out.println(
                         "There is diff that requires recomputing indexes. Shutting down server and recomputing...");
+                TileCache.clear();
                 Server.terminate();
             } else {
                 System.out.println(


### PR DESCRIPTION
Made changes so that the cache clears every time a new project comes in or the indexes are recomputed. Also added the project name to the key for the tile cache.

closes #87