### PR TITLE
another batch of improvements for kyrix-S

### DIFF
--- a/back-end/pom.xml
+++ b/back-end/pom.xml
@@ -70,5 +70,11 @@
             <artifactId>rtree</artifactId>
             <version>0.8-RC10</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.vlsi.compactmap</groupId>
+            <artifactId>compactmap</artifactId>
+            <version>1.3.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/back-end/src/main/java/index/AutoDDInMemoryIndexer.java
+++ b/back-end/src/main/java/index/AutoDDInMemoryIndexer.java
@@ -33,19 +33,12 @@ public class AutoDDInMemoryIndexer extends PsqlSpatialIndexer {
         ArrayList<ArrayList<Double>> convexHull;
         ArrayList<HashMap<String, String>> topk;
 
-        RTreeData() {
-            row = new ArrayList<>();
-            numericalAggs = new HashMap<>();
-            convexHull = new ArrayList<>();
-            topk = new ArrayList<>();
-        }
-
         RTreeData(ArrayList<String> _row) {
             row = new ArrayList<>();
             for (int i = 0; i < _row.size(); i++) row.add(_row.get(i));
-            numericalAggs = new HashMap<>();
-            convexHull = new ArrayList<>();
-            topk = new ArrayList<>();
+            numericalAggs = null;
+            convexHull = null;
+            topk = null;
         }
 
         public String getClusterAggString() {
@@ -477,6 +470,9 @@ public class AutoDDInMemoryIndexer extends PsqlSpatialIndexer {
 
     private void setInitialClusterAgg(RTreeData rd) {
         ArrayList<String> row = rd.row;
+        rd.numericalAggs = new HashMap<>();
+        rd.convexHull = new ArrayList<>();
+        rd.topk = new ArrayList<>();
 
         // count(*)
         rd.numericalAggs.put("count(*)", 1.0);
@@ -540,6 +536,11 @@ public class AutoDDInMemoryIndexer extends PsqlSpatialIndexer {
     // this function assumes that convexHull of child
     // is from one level lower than parent
     private void mergeClusterAgg(RTreeData parent, RTreeData child) {
+
+        // initialize parents
+        if (parent.numericalAggs == null) parent.numericalAggs = new HashMap<>();
+        if (parent.convexHull == null) parent.convexHull = new ArrayList<>();
+        if (parent.topk == null) parent.topk = new ArrayList<>();
 
         // count(*)
         if (!parent.numericalAggs.containsKey("count(*)"))

--- a/back-end/src/main/java/index/AutoDDInMemoryIndexer.java
+++ b/back-end/src/main/java/index/AutoDDInMemoryIndexer.java
@@ -516,6 +516,8 @@ public class AutoDDInMemoryIndexer extends PsqlNativeBoxIndexer {
                 // sum, avg, max, min, count
                 rd.numericalAggs.put(curKey, curValue);
         }
+        // add count(*) if does not exist
+        if (!rd.numericalAggs.containsKey("count(*)")) rd.numericalAggs.put("count(*)", 1.0);
     }
 
     // this function assumes that convexHull of child

--- a/back-end/src/main/java/main/DbConnector.java
+++ b/back-end/src/main/java/main/DbConnector.java
@@ -71,7 +71,15 @@ public class DbConnector {
         Statement stmt = DbConnector.getStmtByDbName(dbName, true);
         ArrayList<ArrayList<String>> ret = getQueryResult(stmt, sql);
         stmt.close();
-        // closeConnection(dbName);
+
+        // We do not close connections here because otherwise
+        // indexers will have to reopen every time before
+        // calling getQueryResult(statement, sql);
+        // It's indexer's job to close the connection at the end
+        // so that the kyrix db (Config.databaseName) is not locked.
+        // At runtime this function is also called by getDataFromRegion().
+        // Closing the connection is then done by Server.java
+        // every time there is a new project request coming in
         return ret;
     }
 

--- a/back-end/src/main/java/main/DbConnector.java
+++ b/back-end/src/main/java/main/DbConnector.java
@@ -68,7 +68,7 @@ public class DbConnector {
     public static ArrayList<ArrayList<String>> getQueryResult(String dbName, String sql)
             throws SQLException, ClassNotFoundException {
 
-        Statement stmt = DbConnector.getStmtByDbName(dbName);
+        Statement stmt = DbConnector.getStmtByDbName(dbName, true);
         ArrayList<ArrayList<String>> ret = getQueryResult(stmt, sql);
         stmt.close();
         // closeConnection(dbName);

--- a/back-end/src/main/java/main/Main.java
+++ b/back-end/src/main/java/main/Main.java
@@ -59,6 +59,17 @@ public class Main {
         DbConnector.executeUpdate(Config.databaseName, sql);
     }
 
+    public static void printUsedMemory(String message) {
+        System.gc();
+        System.out.println(
+                message
+                        + ": "
+                        + (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
+                                / 1024
+                                / 1024
+                        + "MB.");
+    }
+
     private static void readConfigFile() throws IOException {
 
         // read config file

--- a/back-end/src/main/java/project/AutoDD.java
+++ b/back-end/src/main/java/project/AutoDD.java
@@ -15,7 +15,7 @@ public class AutoDD {
     private int topk;
     private String clusterMode, zOrder;
     private ArrayList<String> columnNames, queriedColumnNames = null, columnTypes = null;
-    private ArrayList<String> aggDimensionFields, aggMeasureFields;
+    private ArrayList<String> aggDimensionFields, aggMeasureFields, aggMeasureFuncs;
     private int numLevels, topLevelWidth, topLevelHeight;
     private double overlap;
     private double zoomFactor;
@@ -137,6 +137,10 @@ public class AutoDD {
 
     public ArrayList<String> getAggMeasureFields() {
         return aggMeasureFields;
+    }
+
+    public ArrayList<String> getAggMeasureFuncs() {
+        return aggMeasureFuncs;
     }
 
     public int getNumLevels() {

--- a/back-end/src/main/java/server/ProjectRequestHandler.java
+++ b/back-end/src/main/java/server/ProjectRequestHandler.java
@@ -19,6 +19,7 @@ public class ProjectRequestHandler implements HttpHandler {
 
     private final Gson gson;
     private static HashMap<String, ArrayList<Project>> projects = new HashMap<>();
+    private static HashMap<String, String> BGRP = new HashMap<>();
 
     public ProjectRequestHandler() {
 
@@ -68,6 +69,10 @@ public class ProjectRequestHandler implements HttpHandler {
             Server.sendResponse(
                     httpExchange, HttpsURLConnection.HTTP_OK, "Good, updating main project.");
 
+            // save old project's BGRP
+            if (Main.getProject() != null)
+                BGRP.put(Main.getProject().getName(), Main.getProject().getBGRP());
+
             // set current project
             Main.setProject(newProject);
 
@@ -83,6 +88,8 @@ public class ProjectRequestHandler implements HttpHandler {
                         "Requesting skip-recompute. Project definition updated. Refresh your web page now!");
                 Indexer.associateIndexer();
                 Main.setProjectClean();
+                if (BGRP.containsKey(newProject.getName()))
+                    newProject.setBGRP(BGRP.get(newProject.getName()));
             } else if (needsReIndex(oldProject, newProject)) {
                 System.out.println(
                         "There is diff that requires recomputing indexes. Shutting down server and recomputing...");
@@ -92,6 +99,8 @@ public class ProjectRequestHandler implements HttpHandler {
                         "The diff does not require recompute. Refresh your web page now!");
                 Indexer.associateIndexer();
                 Main.setProjectClean();
+                if (BGRP.containsKey(newProject.getName()))
+                    newProject.setBGRP(BGRP.get(newProject.getName()));
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -40,6 +40,7 @@ public class Server {
             while (!terminated) terminationLock.wait();
         }
         Server.stopServer();
+        DbConnector.closeConnection(Config.databaseName);
         Indexer.precompute();
         Main.setProjectClean();
         System.out.println("Completed recomputing indexes. Server restarting...");

--- a/compiler/examples/template-api-examples/AutoDD_circle.js
+++ b/compiler/examples/template-api-examples/AutoDD_circle.js
@@ -4,7 +4,7 @@ const AutoDD = require("../../src/template-api/AutoDD").AutoDD;
 const renderers = require("../nba/renderers");
 
 // construct a project
-var p = new Project("nba_autodd", "../../../config.txt");
+var p = new Project("autodd_circle", "../../../config.txt");
 p.addRenderingParams(renderers.renderingParams);
 p.addStyles("../nba/nba.css");
 

--- a/compiler/examples/template-api-examples/AutoDD_contour.js
+++ b/compiler/examples/template-api-examples/AutoDD_contour.js
@@ -4,7 +4,7 @@ const AutoDD = require("../../src/template-api/AutoDD").AutoDD;
 const renderers = require("../nba/renderers");
 
 // construct a project
-var p = new Project("nba_autodd", "../../../config.txt");
+var p = new Project("autodd_contour", "../../../config.txt");
 p.addRenderingParams(renderers.renderingParams);
 p.addStyles("../nba/nba.css");
 

--- a/compiler/examples/template-api-examples/AutoDD_custom.js
+++ b/compiler/examples/template-api-examples/AutoDD_custom.js
@@ -4,7 +4,7 @@ const AutoDD = require("../../src/template-api/AutoDD").AutoDD;
 const renderers = require("../nba/renderers");
 
 // construct a project
-var p = new Project("nba_autodd", "../../../config.txt");
+var p = new Project("autodd_custom", "../../../config.txt");
 p.addRenderingParams(renderers.renderingParams);
 p.addStyles("../nba/nba.css");
 

--- a/compiler/examples/template-api-examples/AutoDD_heatmap.js
+++ b/compiler/examples/template-api-examples/AutoDD_heatmap.js
@@ -4,7 +4,7 @@ const AutoDD = require("../../src/template-api/AutoDD").AutoDD;
 const renderers = require("../nba/renderers");
 
 // construct a project
-var p = new Project("nba_autodd", "../../../config.txt");
+var p = new Project("autodd_heatmap", "../../../config.txt");
 p.addRenderingParams(renderers.renderingParams);
 p.addStyles("../nba/nba.css");
 

--- a/compiler/examples/template-api-examples/AutoDD_pie.js
+++ b/compiler/examples/template-api-examples/AutoDD_pie.js
@@ -4,7 +4,7 @@ const AutoDD = require("../../src/template-api/AutoDD").AutoDD;
 const renderers = require("./renderers");
 
 // construct a project
-var p = new Project("fifa_autodd", "../../../config.txt");
+var p = new Project("autodd_pie", "../../../config.txt");
 p.addRenderingParams(renderers.renderingParams);
 p.addStyles(renderers.playerRenderingStyles);
 

--- a/compiler/examples/template-api-examples/AutoDD_radar.js
+++ b/compiler/examples/template-api-examples/AutoDD_radar.js
@@ -9,7 +9,7 @@ const AutoDD = require("../../src/template-api/AutoDD").AutoDD;
 const renderers = require("./renderers");
 
 // construct a project
-var p = new Project("fifa_autodd", "../../../config.txt");
+var p = new Project("autodd_radar", "../../../config.txt");
 p.addRenderingParams(renderers.renderingParams);
 p.addStyles(renderers.playerRenderingStyles);
 

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -1104,7 +1104,6 @@ function getLayerRenderer(level, autoDDArrayIndex) {
     function processClusterAgg() {
         function getConvexCoordinates(d) {
             var coords = d.clusterAgg.convexHull;
-            if (typeof coords == "string") coords = JSON.parse(coords);
             var convexHull = [];
             for (var i = 0; i < coords.length; i++) {
                 convexHull.push({
@@ -1307,8 +1306,6 @@ function getLayerRenderer(level, autoDDArrayIndex) {
                     // use params.bboxH(W) for bounding box size
                     var g = svg.append("g").attr("id", "autodd_ranklist_hover");
                     var topKData = d.clusterAgg.topk;
-                    if (typeof topKData == "string")
-                        topKData = JSON.parse(topKData);
                     var topk = topKData.length;
                     for (var i = 0; i < topk; i++) {
                         topKData[i].cx = +d.cx;

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -269,6 +269,11 @@ function AutoDD(args) {
      ************************/
     this.clusterParams =
         "config" in args.marks.cluster ? args.marks.cluster.config : {};
+    // precision parameters
+    setPropertiesIfNotExists(this.clusterParams, {
+        precisionDecimal0: 1,
+        precisionDecimal1: 0
+    });
     if (args.marks.cluster.mode == "circle")
         setPropertiesIfNotExists(this.clusterParams, {
             circleMinSize: 30,
@@ -524,7 +529,11 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .append("text")
             .attr("dy", "0.3em")
             .text(function(d) {
-                return params.toLargeNumberNotation(+d.clusterAgg[agg]);
+                return params.toLargeNumberNotation(
+                    +d.clusterAgg[agg],
+                    params.precisionDecimal0,
+                    params.precisionDecimal1
+                );
             })
             .attr("font-size", function(d) {
                 return circleSizeInterpolator(d.clusterAgg[agg]) / 2;
@@ -569,7 +578,9 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .append("text")
             .text(function(d) {
                 return args.renderingParams.toLargeNumberNotation(
-                    +d.clusterAgg["count(*)"]
+                    +d.clusterAgg["count(*)"],
+                    params.precisionDecimal0,
+                    params.precisionDecimal1
                 );
             })
             .attr("x", function(d) {
@@ -963,7 +974,11 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             d3.select(nodes[j])
                 .append("text")
                 .text(function(d) {
-                    return d.clusterAgg["count(*)"];
+                    return params.toLargeNumberNotation(
+                        d.clusterAgg["count(*)"],
+                        params.precisionDecimal0,
+                        params.precisionDecimal1
+                    );
                 })
                 .attr("font-size", 25)
                 .attr("x", function(d) {
@@ -1081,7 +1096,13 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .enter()
             .append("text")
             .classed("cluster_num", true)
-            .text(d => d.clusterAgg["count(*)"])
+            .text(d =>
+                params.toLargeNumberNotation(
+                    +d.clusterAgg["count(*)"],
+                    params.precisionDecimal0,
+                    params.precisionDecimal1
+                )
+            )
             .attr("x", d => +d.cx)
             .attr("y", d => +d.cy - params.pieOuterRadius)
             // .attr("dy", ".35em")
@@ -1223,10 +1244,11 @@ function getLayerRenderer(level, autoDDArrayIndex) {
                 var maxlen = 0;
                 for (var j = 0; j < data.length; j++) {
                     if (!isNaN(data[j][fields[i]]))
-                        data[j][fields[i]] =
-                            Math.round(
-                                (+data[j][fields[i]] + Number.EPSILON) * 100
-                            ) / 100;
+                        data[j][fields[i]] = params.toLargeNumberNotation(
+                            +data[j][fields[i]],
+                            params.precisionDecimal0,
+                            params.precisionDecimal1
+                        );
                     maxlen = Math.max(
                         maxlen,
                         data[j][fields[i]].toString().length

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -468,6 +468,8 @@ function getLayerRenderer(level, autoDDArrayIndex) {
         var params = args.renderingParams;
         var aggKeyDelimiter = "REPLACE_ME_agg_key_delimiter";
         REPLACE_ME_processClusterAgg();
+
+        // set up d3.scale for circle/text size
         var agg;
         if (params.aggMeasures.length == 0) agg = "count(*)";
         else {
@@ -481,20 +483,10 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .scaleSqrt()
             .domain([minDomain, maxDomain])
             .range([params.circleMinSize, params.circleMaxSize]);
+
+        // append circles & text
         var g = svg.append("g").classed("hovercircle", true);
         g.style("opacity", 0);
-
-        // filter
-        /*        var defs = g.append("defs");
-        var filter = defs.append("filter").attr("id", "filter-demo-glow");
-        var feGaussianBlur = filter
-            .append("feGaussianBlur")
-            .attr("stdDeviation", "2")
-            .attr("result", "coloredBlur");
-        var feMerge = filter.append("feMerge");
-        feMerge.append("feMergeNode").attr("in", "coloredBlur");
-        feMerge.append("feMergeNode").attr("in", "SourceGraphic"); */
-
         g.selectAll("circle")
             .data(data)
             .enter()
@@ -513,7 +505,6 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .attr("fill", "#d7dbff")
             //            .attr("stroke", "#ADADAD")
             //            .style("stroke-width", "1px")
-            //            .style("filter", "url(#filter-demo-glow)")
             .style("pointer-events", "fill")
             .classed("kyrix-retainsizezoom", true);
         g.selectAll("text")

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -476,7 +476,7 @@ function getLayerRenderer(level, autoDDArrayIndex) {
         }
         var minDomain = params["REPLACE_ME_autoDDId_" + agg + "_min"];
         var maxDomain = params["REPLACE_ME_autoDDId_" + agg + "_max"];
-        agg = aggKeyDelimiter + agg;
+        if (agg !== "count(*)") agg = aggKeyDelimiter + agg;
         var circleSizeInterpolator = d3
             .scaleSqrt()
             .domain([minDomain, maxDomain])
@@ -485,7 +485,7 @@ function getLayerRenderer(level, autoDDArrayIndex) {
         g.style("opacity", 0);
 
         // filter
-        var defs = g.append("defs");
+        /*        var defs = g.append("defs");
         var filter = defs.append("filter").attr("id", "filter-demo-glow");
         var feGaussianBlur = filter
             .append("feGaussianBlur")
@@ -493,7 +493,7 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .attr("result", "coloredBlur");
         var feMerge = filter.append("feMerge");
         feMerge.append("feMergeNode").attr("in", "coloredBlur");
-        feMerge.append("feMergeNode").attr("in", "SourceGraphic");
+        feMerge.append("feMergeNode").attr("in", "SourceGraphic"); */
 
         g.selectAll("circle")
             .data(data)
@@ -1242,11 +1242,17 @@ function getLayerRenderer(level, autoDDArrayIndex) {
                 totalH = data.length * (charH + paddingH) + headerH;
             for (var i = 0; i < fields.length; i++) {
                 var maxlen = 0;
-                for (var j = 0; j < data.length; j++)
+                for (var j = 0; j < data.length; j++) {
+                    if (!isNaN(data[j][fields[i]]))
+                        data[j][fields[i]] =
+                            Math.round(
+                                (+data[j][fields[i]] + Number.EPSILON) * 100
+                            ) / 100;
                     maxlen = Math.max(
                         maxlen,
                         data[j][fields[i]].toString().length
                     );
+                }
                 maxlen = Math.max(maxlen, fields[i].length);
                 widths.push(maxlen * charW + paddingW);
                 totalW += widths[i];

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -572,6 +572,7 @@ function getLayerRenderer(level, autoDDArrayIndex) {
 
     function renderObjectClusterNumBody() {
         var g = svg.select("g:last-of-type");
+        var params = args.renderingParams;
         data.forEach(d => {
             d.clusterAgg = JSON.parse(d.clusterAgg);
         });

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -184,7 +184,10 @@ function AutoDD(args) {
             "Constructing AutoDD: dimension columns (args.marks.cluster.aggregate.dimensions) not allowed for the given cluster mode."
         );
     if (
-        args.marks.cluster.mode == "circle" && //TODO: heatmap and contour are suject to this too
+        (args.marks.cluster.mode == "circle" ||
+            args.marks.cluster.mode == "heatmap" ||
+            args.marks.cluster.mode == "contour" ||
+            args.marks.cluster.mode == "pie") &&
         args.marks.cluster.aggregate.measures.length > 1
     )
         throw new Error(

--- a/compiler/src/template-api/Utilities.js
+++ b/compiler/src/template-api/Utilities.js
@@ -199,18 +199,24 @@ function serializePath(path) {
  * @param ct
  * @returns {*}
  */
-function toLargeNumberNotation(ct) {
-    if (ct < 1000) return ct.toFixed(1);
+function toLargeNumberNotation(ct, d0 = 1, d1 = 0) {
+    // d0 is the number of decimals for ct < 1000
+    // d1 is the number of decimals for ct > 1000
+    if (ct < 1000)
+        return (
+            Math.round((ct + Number.EPSILON) * Math.pow(10, d0)) /
+            Math.pow(10, d0)
+        );
     if (ct >= 1000 && ct < 1000000) {
         ct /= 1000.0;
-        return ct.toFixed(0) + "K";
+        return ct.toFixed(d1) + "K";
     }
     if (ct > 1000000 && ct < 1000000000) {
         ct /= 1000000.0;
-        return ct.toFixed(0) + "M";
+        return ct.toFixed(d1) + "M";
     } else {
         ct /= 1000000000.0;
-        return ct.toFixed(0) + "B";
+        return ct.toFixed(d1) + "B";
     }
     return "";
 }

--- a/compiler/src/template-api/Utilities.js
+++ b/compiler/src/template-api/Utilities.js
@@ -200,7 +200,7 @@ function serializePath(path) {
  * @returns {*}
  */
 function toLargeNumberNotation(ct) {
-    if (ct < 1000) return ct;
+    if (ct < 1000) return ct.toFixed(1);
     if (ct >= 1000 && ct < 1000000) {
         ct /= 1000.0;
         return ct.toFixed(0) + "K";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,5 +65,5 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-kyrixftw}
       KYRIX_PORT: ${KYRIX_PORT:-8000}
       START_APP: ${START_APP:-0}
-      KYRIX_MAVEN_OPTS: "-Xmx2048m"   #2G for JVM memory
+      KYRIX_MAVEN_OPTS: ${KYRIX_MAVEN_OPTS:-"-Xmx2048m"}   #2G for JVM memory
     entrypoint: sh -c 'sleep 5; /wait-for-postgres db:5432 -t 60 -- /start-kyrix.sh; tail -f /dev/null'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,5 +65,5 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-kyrixftw}
       KYRIX_PORT: ${KYRIX_PORT:-8000}
       START_APP: ${START_APP:-0}
-      KYRIX_MAVEN_OPTS: ${KYRIX_MAVEN_OPTS:-"-Xmx2048m"}   #2G for JVM memory
+      KYRIX_MAVEN_OPTS: ${KYRIX_MAVEN_OPTS:-"-Xmx512m"}   # default 512M JVM memory
     entrypoint: sh -c 'sleep 5; /wait-for-postgres db:5432 -t 60 -- /start-kyrix.sh; tail -f /dev/null'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,5 +65,5 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-kyrixftw}
       KYRIX_PORT: ${KYRIX_PORT:-8000}
       START_APP: ${START_APP:-0}
-      MAVEN_OPTS: "-Xmx2048m"   #2G for JVM memory
+      KYRIX_MAVEN_OPTS: "-Xmx2048m"   #2G for JVM memory
     entrypoint: sh -c 'sleep 5; /wait-for-postgres db:5432 -t 60 -- /start-kyrix.sh; tail -f /dev/null'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,5 +65,5 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-kyrixftw}
       KYRIX_PORT: ${KYRIX_PORT:-8000}
       START_APP: ${START_APP:-0}
-      MAVEN_OPTS: "-d64 -Xmx10g"
+      MAVEN_OPTS: "-Xmx2048m"   #2G for JVM memory
     entrypoint: sh -c 'sleep 5; /wait-for-postgres db:5432 -t 60 -- /start-kyrix.sh; tail -f /dev/null'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,4 +65,5 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-kyrixftw}
       KYRIX_PORT: ${KYRIX_PORT:-8000}
       START_APP: ${START_APP:-0}
+      MAVEN_OPTS: "-d64 -Xmx10g"
     entrypoint: sh -c 'sleep 5; /wait-for-postgres db:5432 -t 60 -- /start-kyrix.sh; tail -f /dev/null'

--- a/docker-scripts/start-kyrix.sh
+++ b/docker-scripts/start-kyrix.sh
@@ -75,7 +75,7 @@ fi
 
 # cleanup maven opts
 rm /etc/mavenrc
-echo $MAVEN_OPTS > /etc/mavenrc
+echo $KYRIX_MAVEN_OPTS > /etc/mavenrc
 
 # starting the backend
 cd /kyrix/back-end

--- a/docker-scripts/start-kyrix.sh
+++ b/docker-scripts/start-kyrix.sh
@@ -73,6 +73,10 @@ if [ "x$START_APP" = "x1" ] || [ "x$SRCDATA_PROJECT_NAME" = "xnba" ]; then
     fi
 fi
 
+# cleanup maven opts
+rm /etc/mavenrc
+echo $MAVEN_OPTS > /etc/mavenrc
+
 # starting the backend
 cd /kyrix/back-end
 

--- a/docker-scripts/start-kyrix.sh
+++ b/docker-scripts/start-kyrix.sh
@@ -76,6 +76,7 @@ fi
 # cleanup maven opts
 rm /etc/mavenrc
 echo $KYRIX_MAVEN_OPTS > /etc/mavenrc
+export MAVEN_OPTS=$KYRIX_MAVEN_OPTS
 
 # starting the backend
 cd /kyrix/back-end

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -573,8 +573,8 @@ function RefreshDynamicLayers(viewId, viewportX, viewportY) {
             if (gvd.animation != param.semanticZoom)
                 d3.selectAll(viewClass + ".oldlayerg")
                     .transition()
-                    .duration(param.literalZoomFadeOutDuration + 200)
-                    //                    .style("opacity", 0)
+                    .duration(param.literalZoomFadeOutDuration)
+                    .style("opacity", 0)
                     .remove();
         });
 }

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -573,8 +573,8 @@ function RefreshDynamicLayers(viewId, viewportX, viewportY) {
             if (gvd.animation != param.semanticZoom)
                 d3.selectAll(viewClass + ".oldlayerg")
                     .transition()
-                    .duration(param.literalZoomFadeOutDuration)
-                    .style("opacity", 0)
+                    .duration(param.literalZoomFadeOutDuration + 200)
+                    //                    .style("opacity", 0)
                     .remove();
         });
 }

--- a/run-kyrix.sh
+++ b/run-kyrix.sh
@@ -6,6 +6,7 @@
 # --kyrixport PORT_NUMBER: Specify the host port number of the kyrix backend container.
 # --postgis: Start the DB container with postgis. You need to either start from scratch or run with --build to let docker rebuild the images.
 # --build: Rebuild the docker images before starting.
+# --mavenopts: Pass in custom Maven configuration.
 
 echo -e "\nStopping existing containers..."
 docker-compose stop
@@ -19,6 +20,7 @@ KYRIX_PORT=8000
 START_APP=0
 BUILD_STAGE="pg-plv8"
 REBUILD=""
+KYRIX_MAVEN_OPTS="-Xmx2048m"
 
 while [[ $# -gt 0 ]]
 do
@@ -46,6 +48,11 @@ do
             REBUILD="--build"
             shift
             ;;
+        --mavenopts)
+            KYRIX_MAVEN_OPTS="$2"
+            shift
+            shift
+            ;
         *)
             echo "Wrong argument name $key"
             exit
@@ -53,7 +60,7 @@ do
     esac
 done
 
-START_APP=$START_APP DB_PORT=$DB_PORT KYRIX_PORT=$KYRIX_PORT BUILD_STAGE=$BUILD_STAGE docker-compose up $REBUILD -d
+START_APP=$START_APP DB_PORT=$DB_PORT KYRIX_PORT=$KYRIX_PORT BUILD_STAGE=$BUILD_STAGE KYRIX_MAVEN_OPTS=$KYRIX_MAVEN_OPTS docker-compose up $REBUILD -d
 
 source docker-scripts/spinner.sh
 # waiting for kyrix_db_1 to start

--- a/run-kyrix.sh
+++ b/run-kyrix.sh
@@ -52,7 +52,7 @@ do
             KYRIX_MAVEN_OPTS="$2"
             shift
             shift
-            ;
+            ;;
         *)
             echo "Wrong argument name $key"
             exit


### PR DESCRIPTION
* support for `avg` in circle mode.
* option to specify JVM memory upon docker start.
* no postgis for SSV indexer.
* using Java built-in `JsonObject` to represent `clusterAgg`, avoiding serializing and de-serializing
* standardized decimal precision control, with two user-specifiable parameters in `cluster.config` component.
* avoiding unnecessary computation of aggregates not specified. 
* one-pass bottom-up clustering, replacing old two-pass sampling & aggregation. 
* lots of optimizations to reduce memory consumption, including: using primitive array types and `com.github.vlsi.compactmap` to represent `clusterAgg`, storing in `clusterAgg` array idx of raw records rather than raw records themselves, replacing many `double` with `float`, etc.
* bug fix: iterative authoring was broken due to unclosed connection of `getDataFromRegion` blocking the database. 
* iterative authoring with BGRP memorized in the backend memory. 