### PR TITLE
Keep backend running when exceptions occur

### DIFF
--- a/back-end/src/main/java/main/DbConnector.java
+++ b/back-end/src/main/java/main/DbConnector.java
@@ -149,4 +149,11 @@ public class DbConnector {
             connections.remove(dbName + "_batch");
         }
     }
+
+    public static void closeAllConnections() throws SQLException {
+        for (String connName : connections.keySet()) {
+            connections.get(connName).close();
+        }
+        connections.clear();
+    }
 }

--- a/back-end/src/main/java/main/Main.java
+++ b/back-end/src/main/java/main/Main.java
@@ -39,7 +39,8 @@ public class Main {
 
     public static void setProject(Project newProject) {
 
-        System.out.println("Current project set to: " + newProject.getName());
+        System.out.println(
+                "Current project set to: " + (newProject != null ? newProject.getName() : "null"));
         project = newProject;
 
         // clear cache whenever there is a project switch

--- a/back-end/src/main/java/project/AutoDD.java
+++ b/back-end/src/main/java/project/AutoDD.java
@@ -19,7 +19,7 @@ public class AutoDD {
     private int numLevels, topLevelWidth, topLevelHeight;
     private double overlap;
     private double zoomFactor;
-    private int xColId = -1, yColId = -1;
+    private int xColId = -1, yColId = -1, zColId = -1;
     private double loX = Double.NaN, loY, hiX, hiY;
     private String mergeClusterAggs,
             getCitusSpatialHashKeyBody,
@@ -78,7 +78,7 @@ public class AutoDD {
 
         if (xColId < 0) {
             ArrayList<String> colNames = getColumnNames();
-            for (int i = 0; i < colNames.size(); i++) if (colNames.get(i).equals(xCol)) xColId = i;
+            xColId = colNames.indexOf(xCol);
         }
         return xColId;
     }
@@ -87,9 +87,18 @@ public class AutoDD {
 
         if (yColId < 0) {
             ArrayList<String> colNames = getColumnNames();
-            for (int i = 0; i < colNames.size(); i++) if (colNames.get(i).equals(yCol)) yColId = i;
+            yColId = colNames.indexOf(yCol);
         }
         return yColId;
+    }
+
+    public int getZColId() {
+
+        if (zColId < 0) {
+            ArrayList<String> colNames = getColumnNames();
+            zColId = colNames.indexOf(zCol);
+        }
+        return zColId;
     }
 
     public ArrayList<String> getColumnNames() {

--- a/back-end/src/main/java/server/BoxRequestHandler.java
+++ b/back-end/src/main/java/server/BoxRequestHandler.java
@@ -34,96 +34,99 @@ public class BoxRequestHandler implements HttpHandler {
         // TODO: this method should be thread safe, allowing concurrent requests
         System.out.println("\nServing /dynamic Box");
 
-        // get data of the current request
-        // variable definitions
-        String response;
-        String canvasId, viewId;
-        double minx, miny;
-        BoxandData data = null;
-
-        // check if this is a POST request
-        if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
-            return;
-        }
-
-        // get data of the current request
-        String query = httpExchange.getRequestURI().getQuery();
-        Map<String, String> queryMap = Server.queryToMap(query);
-        // print
-        for (String s : queryMap.keySet()) System.out.println(s + " : " + queryMap.get(s));
-
-        // check parameters, if not pass, send a bad request response
-        response = checkParameters(queryMap);
-        if (response.length() > 0) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, response);
-            return;
-        }
-        // get parameters
-        canvasId = queryMap.get("id");
-        viewId = queryMap.get("viewId");
-        minx = Double.valueOf(queryMap.get("x"));
-        miny = Double.valueOf(queryMap.get("y"));
-        Canvas c = null;
         try {
+            // get data of the current request
+            // variable definitions
+            String response;
+            String canvasId, viewId;
+            double minx, miny;
+            BoxandData data = null;
+
+            // check if this is a POST request
+            if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
+                return;
+            }
+
+            // get data of the current request
+            String query = httpExchange.getRequestURI().getQuery();
+            Map<String, String> queryMap = Server.queryToMap(query);
+            // print
+            for (String s : queryMap.keySet()) System.out.println(s + " : " + queryMap.get(s));
+
+            // check parameters, if not pass, send a bad request response
+            response = checkParameters(queryMap);
+            if (response.length() > 0) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, response);
+                return;
+            }
+            // get parameters
+            canvasId = queryMap.get("id");
+            viewId = queryMap.get("viewId");
+            minx = Double.valueOf(queryMap.get("x"));
+            miny = Double.valueOf(queryMap.get("y"));
+            Canvas c = null;
             c = Main.getProject().getCanvas(canvasId).deepCopy();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        View v = Main.getProject().getView(viewId);
-        if (queryMap.containsKey("canvasw")) c.setW(Integer.valueOf(queryMap.get("canvasw")));
-        if (queryMap.containsKey("canvash")) c.setH(Integer.valueOf(queryMap.get("canvash")));
-        ArrayList<String> predicates = new ArrayList<>();
-        for (int i = 0; i < c.getLayers().size(); i++)
-            predicates.add(queryMap.get("predicate" + i));
-        double oMinX = Double.valueOf(queryMap.get("oboxx"));
-        double oMinY = Double.valueOf(queryMap.get("oboxy"));
-        double oMaxX = oMinX + Double.valueOf(queryMap.get("oboxw"));
-        double oMaxY = oMinY + Double.valueOf(queryMap.get("oboxh"));
-        Box oldBox = new Box(oMinX, oMinY, oMaxX, oMaxY);
-        Boolean isJumping = Boolean.valueOf(queryMap.get("isJumping"));
+            View v = Main.getProject().getView(viewId);
+            if (queryMap.containsKey("canvasw")) c.setW(Integer.valueOf(queryMap.get("canvasw")));
+            if (queryMap.containsKey("canvash")) c.setH(Integer.valueOf(queryMap.get("canvash")));
+            ArrayList<String> predicates = new ArrayList<>();
+            for (int i = 0; i < c.getLayers().size(); i++)
+                predicates.add(queryMap.get("predicate" + i));
+            double oMinX = Double.valueOf(queryMap.get("oboxx"));
+            double oMinY = Double.valueOf(queryMap.get("oboxy"));
+            double oMaxX = oMinX + Double.valueOf(queryMap.get("oboxw"));
+            double oMaxY = oMinY + Double.valueOf(queryMap.get("oboxh"));
+            Box oldBox = new Box(oMinX, oMinY, oMaxX, oMaxY);
+            Boolean isJumping = Boolean.valueOf(queryMap.get("isJumping"));
 
-        // get box data
-        long st = System.currentTimeMillis();
-        try {
+            // get box data
+            long st = System.currentTimeMillis();
             data = boxGetter.getBox(c, v, minx, miny, oldBox, predicates);
+            double fetchTime = System.currentTimeMillis() - st;
+            int intersectingRows = 0;
+            for (int i = 0; i < data.data.size(); i++) {
+                intersectingRows += data.data.get(i).size();
+            }
+            System.out.println("Fetch data time: " + fetchTime + "ms.");
+            System.out.println("number of intersecting rows in result: " + intersectingRows);
+
+            // TODO: improve this by not sending insert query every time there is a user
+            // interaction,
+            // instead, store in prepare statement (idk if that would work?)
+            //  or in-memory data structure and flush to db in batches
+            if (isJumping) {
+                Server.sendStats(
+                        Main.getProject().getName(),
+                        c.getId(),
+                        "jump",
+                        fetchTime,
+                        intersectingRows);
+            } else {
+                Server.sendStats(
+                        Main.getProject().getName(), c.getId(), "pan", fetchTime, intersectingRows);
+            }
+
+            // send data and box back
+            Map<String, Object> respMap = new HashMap<>();
+            respMap.put("renderData", BoxandData.getDictionaryFromData(data.data, c));
+            respMap.put("minx", data.box.getMinx());
+            respMap.put("miny", data.box.getMiny());
+            respMap.put("boxH", data.box.getHeight());
+            respMap.put("boxW", data.box.getWidth());
+            respMap.put("canvasId", canvasId);
+            response = gson.toJson(respMap);
+
+            // send back response
+            st = System.currentTimeMillis();
+            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
+            System.out.println("Send response time: " + (System.currentTimeMillis() - st) + "ms.");
+            System.out.println();
         } catch (Exception e) {
             e.printStackTrace();
+            System.out.println("\n\n" + e.getMessage() + "\n");
+            Server.printServingErrorMessage();
         }
-        double fetchTime = System.currentTimeMillis() - st;
-        int intersectingRows = 0;
-        for (int i = 0; i < data.data.size(); i++) {
-            intersectingRows += data.data.get(i).size();
-        }
-        System.out.println("Fetch data time: " + fetchTime + "ms.");
-        System.out.println("number of intersecting rows in result: " + intersectingRows);
-
-        // TODO: improve this by not sending insert query every time there is a user interaction,
-        // instead, store in prepare statement (idk if that would work?)
-        //  or in-memory data structure and flush to db in batches
-        if (isJumping) {
-            Server.sendStats(
-                    Main.getProject().getName(), c.getId(), "jump", fetchTime, intersectingRows);
-        } else {
-            Server.sendStats(
-                    Main.getProject().getName(), c.getId(), "pan", fetchTime, intersectingRows);
-        }
-
-        // send data and box back
-        Map<String, Object> respMap = new HashMap<>();
-        respMap.put("renderData", BoxandData.getDictionaryFromData(data.data, c));
-        respMap.put("minx", data.box.getMinx());
-        respMap.put("miny", data.box.getMiny());
-        respMap.put("boxH", data.box.getHeight());
-        respMap.put("boxW", data.box.getWidth());
-        respMap.put("canvasId", canvasId);
-        response = gson.toJson(respMap);
-
-        // send back response
-        st = System.currentTimeMillis();
-        Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
-        System.out.println("Send response time: " + (System.currentTimeMillis() - st) + "ms.");
-        System.out.println();
     }
 
     private String checkParameters(Map<String, String> queryMap) {

--- a/back-end/src/main/java/server/CanvasRequestHandler.java
+++ b/back-end/src/main/java/server/CanvasRequestHandler.java
@@ -33,66 +33,58 @@ public class CanvasRequestHandler implements HttpHandler {
 
         System.out.println("Serving /canvas");
 
-        // check if this is a POST request
-        if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
-            return;
-        }
-
-        // get data of the current request
-        String query = httpExchange.getRequestURI().getQuery();
-        Map<String, String> queryMap = Server.queryToMap(query);
-        String canvasId = queryMap.get("id");
-
-        // get the current canvas
-        Canvas c = null;
         try {
+            // check if this is a POST request
+            if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
+                return;
+            }
+
+            // get data of the current request
+            String query = httpExchange.getRequestURI().getQuery();
+            Map<String, String> queryMap = Server.queryToMap(query);
+            String canvasId = queryMap.get("id");
+
+            // get the current canvas
+            Canvas c = null;
             c = Main.getProject().getCanvas(canvasId).deepCopy();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
 
-        // list of predicates
-        ArrayList<String> predicates = new ArrayList<>();
-        for (int i = 0; i < c.getLayers().size(); i++)
-            predicates.add(queryMap.get("predicate" + i));
+            // list of predicates
+            ArrayList<String> predicates = new ArrayList<>();
+            for (int i = 0; i < c.getLayers().size(); i++)
+                predicates.add(queryMap.get("predicate" + i));
 
-        // calculate w or h if they are not pre-determined
-        if (c.getwSql().length() > 0) {
-            String predicate = queryMap.get("predicate" + c.getwLayerId());
-            String sql = c.getwSql() + (predicate.length() > 0 ? " and " + predicate : "");
-            String db = c.getDbByLayerId(c.getwLayerId());
-            try {
+            // calculate w or h if they are not pre-determined
+            if (c.getwSql().length() > 0) {
+                String predicate = queryMap.get("predicate" + c.getwLayerId());
+                String sql = c.getwSql() + (predicate.length() > 0 ? " and " + predicate : "");
+                String db = c.getDbByLayerId(c.getwLayerId());
                 c.setW(getWidthOrHeightBySql(sql, db));
-            } catch (Exception e) {
             }
-        }
-        if (c.gethSql().length() > 0) {
-            String predicate = queryMap.get("predicate" + c.gethLayerId());
-            String sql = c.gethSql() + (predicate.length() > 0 ? " and " + predicate : "");
-            String db = c.getDbByLayerId(c.gethLayerId());
-            try {
+            if (c.gethSql().length() > 0) {
+                String predicate = queryMap.get("predicate" + c.gethLayerId());
+                String sql = c.gethSql() + (predicate.length() > 0 ? " and " + predicate : "");
+                String db = c.getDbByLayerId(c.gethLayerId());
                 c.setH(getWidthOrHeightBySql(sql, db));
-            } catch (Exception e) {
             }
-        }
 
-        // get static data
-        ArrayList<ArrayList<ArrayList<String>>> staticData = null;
-        try {
+            // get static data
+            ArrayList<ArrayList<ArrayList<String>>> staticData = null;
             staticData = getStaticData(c, predicates);
+
+            // construct the response object
+            Map<String, Object> respMap = new HashMap<>();
+            respMap.put("canvas", c);
+            respMap.put("staticData", BoxandData.getDictionaryFromData(staticData, c));
+            String response = gson.toJson(respMap);
+
+            // send the response back
+            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
         } catch (Exception e) {
             e.printStackTrace();
+            System.out.println("\n\n" + e.getMessage() + "\n");
+            Server.printServingErrorMessage();
         }
-
-        // construct the response object
-        Map<String, Object> respMap = new HashMap<>();
-        respMap.put("canvas", c);
-        respMap.put("staticData", BoxandData.getDictionaryFromData(staticData, c));
-        String response = gson.toJson(respMap);
-
-        // send the response back
-        Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
     }
 
     private int getWidthOrHeightBySql(String sql, String db)

--- a/back-end/src/main/java/server/FirstRequestHandler.java
+++ b/back-end/src/main/java/server/FirstRequestHandler.java
@@ -27,23 +27,29 @@ public class FirstRequestHandler implements HttpHandler {
 
         System.out.println("Serving /first");
 
-        // check if this is a POST request
-        if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
-            return;
+        try {
+            // check if this is a POST request
+            if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
+                return;
+            }
+
+            // get the project
+            Project project = Main.getProject();
+
+            // construct a response map
+            Map<String, Object> respMap = new HashMap<>();
+            respMap.put("project", project);
+            respMap.put("tileH", Config.tileH);
+            respMap.put("tileW", Config.tileW);
+
+            // convert the response to a json object and send it back
+            String response = gson.toJson(respMap);
+            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("\n\n" + e.getMessage() + "\n");
+            Server.printServingErrorMessage();
         }
-
-        // get the project
-        Project project = Main.getProject();
-
-        // construct a response map
-        Map<String, Object> respMap = new HashMap<>();
-        respMap.put("project", project);
-        respMap.put("tileH", Config.tileH);
-        respMap.put("tileW", Config.tileW);
-
-        // convert the response to a json object and send it back
-        String response = gson.toJson(respMap);
-        Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
     }
 }

--- a/back-end/src/main/java/server/IndexHandler.java
+++ b/back-end/src/main/java/server/IndexHandler.java
@@ -14,32 +14,39 @@ public class IndexHandler implements HttpHandler {
     public void handle(HttpExchange httpExchange) throws IOException {
 
         System.out.println("Serving /");
-        System.out.println(httpExchange.getRequestURI().getPath());
 
-        // check if it is GET request
-        if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
-            return;
+        try {
+            System.out.println(httpExchange.getRequestURI().getPath());
+
+            // check if it is GET request
+            if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
+                return;
+            }
+
+            String path = httpExchange.getRequestURI().getPath();
+            if (path.equals("/")) path = "/" + Config.indexFileName;
+
+            // read the frontend file and return
+            FileInputStream fs = new FileInputStream(Config.webRoot + path);
+            final byte[] content = new byte[0x1000000];
+            int len = fs.read(content);
+
+            // send back a ok response
+            if (path.contains(".svg")) // todo: better file checking for the index handler
+            Server.sendResponse(
+                        httpExchange, HttpsURLConnection.HTTP_OK, content, len, "image/svg+xml");
+            else if (path.contains(".png"))
+                Server.sendResponse(
+                        httpExchange, HttpsURLConnection.HTTP_OK, content, len, "image/png");
+            else if (path.contains(".jpg"))
+                Server.sendResponse(
+                        httpExchange, HttpsURLConnection.HTTP_OK, content, len, "image/jpg");
+            else Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, content, len);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("\n\n" + e.getMessage() + "\n");
+            Server.printServingErrorMessage();
         }
-
-        String path = httpExchange.getRequestURI().getPath();
-        if (path.equals("/")) path = "/" + Config.indexFileName;
-
-        // read the frontend file and return
-        FileInputStream fs = new FileInputStream(Config.webRoot + path);
-        final byte[] content = new byte[0x1000000];
-        int len = fs.read(content);
-
-        // send back a ok response
-        if (path.contains(".svg")) // todo: better file checking for the index handler
-        Server.sendResponse(
-                    httpExchange, HttpsURLConnection.HTTP_OK, content, len, "image/svg+xml");
-        else if (path.contains(".png"))
-            Server.sendResponse(
-                    httpExchange, HttpsURLConnection.HTTP_OK, content, len, "image/png");
-        else if (path.contains(".jpg"))
-            Server.sendResponse(
-                    httpExchange, HttpsURLConnection.HTTP_OK, content, len, "image/jpg");
-        else Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, content, len);
     }
 }

--- a/back-end/src/main/java/server/ProjectRequestHandler.java
+++ b/back-end/src/main/java/server/ProjectRequestHandler.java
@@ -44,9 +44,9 @@ public class ProjectRequestHandler implements HttpHandler {
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
 
-        try {
-            System.out.println("\n\nServing /project\n New project definition coming...");
+        System.out.println("\n\nServing /project\n New project definition coming...");
 
+        try {
             // check if this is a POST request
             if (!httpExchange.getRequestMethod().equalsIgnoreCase("POST")) {
                 Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
@@ -104,6 +104,8 @@ public class ProjectRequestHandler implements HttpHandler {
             }
         } catch (Exception e) {
             e.printStackTrace();
+            System.out.println("\n\n" + e.getMessage() + "\n");
+            Server.printServingErrorMessage();
         }
     }
 

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -40,10 +40,33 @@ public class Server {
             while (!terminated) terminationLock.wait();
         }
         Server.stopServer();
-        DbConnector.closeConnection(Config.databaseName);
-        Indexer.precompute();
-        Main.setProjectClean();
-        System.out.println("Completed recomputing indexes. Server restarting...");
+        try {
+            DbConnector.closeConnection(Config.databaseName);
+            Indexer.precompute();
+            Main.setProjectClean();
+            System.out.println("Completed recomputing indexes. Server restarting...");
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("\n\n" + e.getMessage() + "\n");
+            System.out.println(
+                    "+---------------------------------------------------------+\n"
+                            + "|ERROR!!! An exception occurred while indexing.           |\n"
+                            + "|This is likely due to errors in database related things, |\n"
+                            + "|e.g. a mis-formed SQL query in the specification, a non- |\n"
+                            + "|existent column you specified, or the data isn't loaded  |\n"
+                            + "|into the database.                                       |\n"
+                            + "|                                                         |\n"
+                            + "|Indexing is now terminated and the server is restarted.  |\n"
+                            + "|Please inspect your spec and database, and then recompile|\n"
+                            + "|the project.If you can't figure out the issue, feel free |\n"
+                            + "|to contact Kyrix maintainers.                            |\n"
+                            + "|                                                         |\n"
+                            + "|Github: https://github.com/tracyhenry/kyrix              |\n"
+                            + "+---------------------------------------------------------+");
+            Main.setProject(null);
+            DbConnector.closeAllConnections();
+            System.out.println("Server restarting....");
+        }
         Server.startServer(Config.portNumber);
     }
 

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -48,26 +48,46 @@ public class Server {
         } catch (Exception e) {
             e.printStackTrace();
             System.out.println("\n\n" + e.getMessage() + "\n");
-            System.out.println(
-                    "+---------------------------------------------------------+\n"
-                            + "|ERROR!!! An exception occurred while indexing.           |\n"
-                            + "|This is likely due to errors in database related things, |\n"
-                            + "|e.g. a mis-formed SQL query in the specification, a non- |\n"
-                            + "|existent column you specified, or the data isn't loaded  |\n"
-                            + "|into the database.                                       |\n"
-                            + "|                                                         |\n"
-                            + "|Indexing is now terminated and the server is restarted.  |\n"
-                            + "|Please inspect your spec and database, and then recompile|\n"
-                            + "|the project.If you can't figure out the issue, feel free |\n"
-                            + "|to contact Kyrix maintainers.                            |\n"
-                            + "|                                                         |\n"
-                            + "|Github: https://github.com/tracyhenry/kyrix              |\n"
-                            + "+---------------------------------------------------------+");
+            printIndexingErrorMessage();
             Main.setProject(null);
             DbConnector.closeAllConnections();
             System.out.println("Server restarting....");
         }
         Server.startServer(Config.portNumber);
+    }
+
+    public static void printIndexingErrorMessage() {
+        System.out.println(
+                "+---------------------------------------------------------+\n"
+                        + "|ERROR!!! An exception occurred while indexing.           |\n"
+                        + "|This is likely due to errors in database related things, |\n"
+                        + "|e.g. a mis-formed SQL query in the specification, a non- |\n"
+                        + "|existent column you specified, or the data isn't loaded  |\n"
+                        + "|into the database.                                       |\n"
+                        + "|                                                         |\n"
+                        + "|Indexing is now terminated and the server is restarted.  |\n"
+                        + "|Please inspect your spec and database, and then recompile|\n"
+                        + "|the project.If you can't figure out the issue, feel free |\n"
+                        + "|to contact Kyrix maintainers.                            |\n"
+                        + "|                                                         |\n"
+                        + "|Github: https://github.com/tracyhenry/kyrix              |\n"
+                        + "+---------------------------------------------------------+");
+    }
+
+    public static void printServingErrorMessage() {
+        System.out.println(
+                "+-------------------------------------------------------------+\n"
+                        + "|ERROR!!! An exception occurred while serving an HTTP request.|\n"
+                        + "|This is likely due to errors in database related things,     |\n"
+                        + "|e.g. a non-existent column you specified, or deleted/-       |\n"
+                        + "|corrupted database indexes.                                  |\n"
+                        + "|                                                             |\n"
+                        + "|The server will continue running, but the error will likely  |\n"
+                        + "|occur again. You can recompile the project to recompute the  |\n"
+                        + "|indexes, or reach out to the kyrix maintainers for help.     |\n"
+                        + "|                                                             |\n"
+                        + "|Github: https://github.com/tracyhenry/kyrix                  |\n"
+                        + "+-------------------------------------------------------------+");
     }
 
     public static void terminate() {

--- a/back-end/src/main/java/server/TileRequestHandler.java
+++ b/back-end/src/main/java/server/TileRequestHandler.java
@@ -32,74 +32,80 @@ public class TileRequestHandler implements HttpHandler {
         // TODO: this method should be thread safe, allowing concurrent requests
         System.out.println("\nServing /tile");
 
-        // variable definitions
-        String response;
-        String canvasId;
-        int minx, miny;
-        ArrayList<ArrayList<ArrayList<String>>> data = null;
-
-        // check if this is a POST request
-        if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
-            return;
-        }
-
-        // get data of the current request
-        String query = httpExchange.getRequestURI().getQuery();
-        Map<String, String> queryMap = Server.queryToMap(query);
-        // print
-        for (String s : queryMap.keySet()) System.out.println(s + " : " + queryMap.get(s));
-
-        // check parameters, if not pass, send a bad request response
-        response = checkParameters(queryMap);
-        if (response.length() > 0) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, response);
-            return;
-        }
-
-        // get data
-        canvasId = queryMap.get("id");
-        minx = Integer.valueOf(queryMap.get("x"));
-        miny = Integer.valueOf(queryMap.get("y"));
-        Canvas c = Main.getProject().getCanvas(canvasId);
-        ArrayList<String> predicates = new ArrayList<>();
-        for (int i = 0; i < c.getLayers().size(); i++)
-            predicates.add(queryMap.get("predicate" + i));
-        Boolean isJumping = Boolean.valueOf(queryMap.get("isJumping"));
-        long st = System.currentTimeMillis();
         try {
+            // variable definitions
+            String response;
+            String canvasId;
+            int minx, miny;
+            ArrayList<ArrayList<ArrayList<String>>> data = null;
+
+            // check if this is a POST request
+            if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
+                return;
+            }
+
+            // get data of the current request
+            String query = httpExchange.getRequestURI().getQuery();
+            Map<String, String> queryMap = Server.queryToMap(query);
+            // print
+            for (String s : queryMap.keySet()) System.out.println(s + " : " + queryMap.get(s));
+
+            // check parameters, if not pass, send a bad request response
+            response = checkParameters(queryMap);
+            if (response.length() > 0) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, response);
+                return;
+            }
+
+            // get data
+            canvasId = queryMap.get("id");
+            minx = Integer.valueOf(queryMap.get("x"));
+            miny = Integer.valueOf(queryMap.get("y"));
+            Canvas c = Main.getProject().getCanvas(canvasId);
+            ArrayList<String> predicates = new ArrayList<>();
+            for (int i = 0; i < c.getLayers().size(); i++)
+                predicates.add(queryMap.get("predicate" + i));
+            Boolean isJumping = Boolean.valueOf(queryMap.get("isJumping"));
+            long st = System.currentTimeMillis();
             data = TileCache.getTile(c, minx, miny, predicates);
+
+            double fetchTime = System.currentTimeMillis() - st;
+            int intersectingRows = 0;
+            for (int i = 0; i < data.size(); i++) {
+                intersectingRows += data.get(i).size();
+            }
+            System.out.println("Fetch data time: " + fetchTime + "ms.");
+            System.out.println("number of intersecting rows in result: " + intersectingRows);
+
+            if (isJumping) {
+                Server.sendStats(
+                        Main.getProject().getName(),
+                        c.getId(),
+                        "jump",
+                        fetchTime,
+                        intersectingRows);
+            } else {
+                Server.sendStats(
+                        Main.getProject().getName(), c.getId(), "pan", fetchTime, intersectingRows);
+            }
+
+            // construct response
+            Map<String, Object> respMap = new HashMap<>();
+            respMap.put("renderData", BoxandData.getDictionaryFromData(data, c));
+            respMap.put("minx", minx);
+            respMap.put("miny", miny);
+            respMap.put("canvasId", canvasId);
+            response = gson.toJson(respMap);
+
+            // send back response
+            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
+            System.out.println();
         } catch (Exception e) {
             e.printStackTrace();
+            System.out.println("\n\n" + e.getMessage() + "\n");
+            Server.printServingErrorMessage();
         }
-
-        double fetchTime = System.currentTimeMillis() - st;
-        int intersectingRows = 0;
-        for (int i = 0; i < data.size(); i++) {
-            intersectingRows += data.get(i).size();
-        }
-        System.out.println("Fetch data time: " + fetchTime + "ms.");
-        System.out.println("number of intersecting rows in result: " + intersectingRows);
-
-        if (isJumping) {
-            Server.sendStats(
-                    Main.getProject().getName(), c.getId(), "jump", fetchTime, intersectingRows);
-        } else {
-            Server.sendStats(
-                    Main.getProject().getName(), c.getId(), "pan", fetchTime, intersectingRows);
-        }
-
-        // construct response
-        Map<String, Object> respMap = new HashMap<>();
-        respMap.put("renderData", BoxandData.getDictionaryFromData(data, c));
-        respMap.put("minx", minx);
-        respMap.put("miny", miny);
-        respMap.put("canvasId", canvasId);
-        response = gson.toJson(respMap);
-
-        // send back response
-        Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
-        System.out.println();
     }
 
     // check paramters

--- a/back-end/src/main/java/server/ViewportRequestHandler.java
+++ b/back-end/src/main/java/server/ViewportRequestHandler.java
@@ -33,57 +33,59 @@ public class ViewportRequestHandler implements HttpHandler {
         // TODO: this method should be thread safe, allowing concurrent requests
         System.out.println("Serving /viewport");
 
-        // variable definitions
-        String response;
-        String canvasId;
-        ArrayList<String> predicates = new ArrayList<>();
-        ArrayList<String> data = null;
-
-        // check if this is a POST request
-        if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
-            return;
-        }
-
-        // get data of the current request
-        String query = httpExchange.getRequestURI().getQuery();
-        Map<String, String> queryMap = Server.queryToMap(query);
-        // print
-        for (String s : queryMap.keySet()) System.out.println(s + " : " + queryMap.get(s));
-        System.out.println();
-
-        // check parameters, if not pass, send a bad request response
-        response = checkParameters(queryMap);
-        if (response.length() > 0) {
-            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, response);
-            return;
-        }
-
-        // get data
-        canvasId = queryMap.get("canvasId");
-        Canvas c = Main.getProject().getCanvas(canvasId);
-        for (int i = 0; i < c.getLayers().size(); i++)
-            predicates.add(queryMap.get("predicate" + i));
         try {
+            // variable definitions
+            String response;
+            String canvasId;
+            ArrayList<String> predicates = new ArrayList<>();
+            ArrayList<String> data = null;
+
+            // check if this is a POST request
+            if (!httpExchange.getRequestMethod().equalsIgnoreCase("GET")) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_METHOD, "");
+                return;
+            }
+
+            // get data of the current request
+            String query = httpExchange.getRequestURI().getQuery();
+            Map<String, String> queryMap = Server.queryToMap(query);
+            // print
+            for (String s : queryMap.keySet()) System.out.println(s + " : " + queryMap.get(s));
+            System.out.println();
+
+            // check parameters, if not pass, send a bad request response
+            response = checkParameters(queryMap);
+            if (response.length() > 0) {
+                Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, response);
+                return;
+            }
+
+            // get data
+            canvasId = queryMap.get("canvasId");
+            Canvas c = Main.getProject().getCanvas(canvasId);
+            for (int i = 0; i < c.getLayers().size(); i++)
+                predicates.add(queryMap.get("predicate" + i));
             data = getData(canvasId, predicates);
+
+            if (data == null) {
+                Server.sendResponse(
+                        httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, "Bad predicates.");
+                return;
+            }
+
+            // construct response
+            Map<String, Object> respMap = new HashMap<>();
+            respMap.put("cx", data.get(0));
+            respMap.put("cy", data.get(1));
+            response = gson.toJson(respMap);
+
+            // send back response
+            Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
         } catch (Exception e) {
             e.printStackTrace();
+            System.out.println("\n\n" + e.getMessage() + "\n");
+            Server.printServingErrorMessage();
         }
-
-        if (data == null) {
-            Server.sendResponse(
-                    httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, "Bad predicates.");
-            return;
-        }
-
-        // construct response
-        Map<String, Object> respMap = new HashMap<>();
-        respMap.put("cx", data.get(0));
-        respMap.put("cy", data.get(1));
-        response = gson.toJson(respMap);
-
-        // send back response
-        Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, response);
     }
 
     private String checkParameters(Map<String, String> queryMap) {


### PR DESCRIPTION
Previously, the backend will throw up whenever there is an exception. The user has to kill docker containers, restart and face possibly corrupted database stuff. This issue has been tracked in #15 

This PR addresses this issue  by placing try/catches in high-level places to catch all possible exceptions. A helper message like the following is printed out after the exception's stack trace:
```
+---------------------------------------------------------+
|ERROR!!! An exception occurred while indexing.           |
|This is likely due to errors in database related things, |
|e.g. a mis-formed SQL query in the specification, a non- |
|existent column you specified, or the data isn't loaded  |
|into the database.                                       |
|                                                         |
|Indexing is now terminated and the server is restarted.  |
|Please inspect your spec and database, and then recompile|
|the project.If you can't figure out the issue, feel free |
|to contact Kyrix maintainers.                            |
|                                                         |
|Github: https://github.com/tracyhenry/kyrix              |
+---------------------------------------------------------+
```
Then, backend state is cleaned up and server is restarted. The user is then able to iteratively refine their spec without stopping docker at all. 

Since #15 is also about checking SQL function/JS script securities (e.g. no DDL, DML), we'll leave it open. 

This PR also has a fix to Kyrix-S which parses double values from strings more robustly. 