### PR TITLE
axes title & styling, tooltip API and bug fixes

### DIFF
--- a/back-end/src/main/java/project/Layer.java
+++ b/back-end/src/main/java/project/Layer.java
@@ -2,6 +2,7 @@ package project;
 
 import index.Indexer;
 import java.io.Serializable;
+import java.util.ArrayList;
 
 /** Created by wenbo on 4/3/18. */
 public class Layer implements Serializable {
@@ -12,6 +13,7 @@ public class Layer implements Serializable {
     private boolean deltaBox;
     private Placement placement;
     private String rendering;
+    private ArrayList<String> tooltipColumns, tooltipAliases;
     private transient Indexer indexer;
     private String autoDDId;
     private String indexerType;

--- a/back-end/src/main/java/server/CanvasRequestHandler.java
+++ b/back-end/src/main/java/server/CanvasRequestHandler.java
@@ -41,7 +41,7 @@ public class CanvasRequestHandler implements HttpHandler {
             }
 
             // get data of the current request
-            String query = httpExchange.getRequestURI().getQuery();
+            String query = httpExchange.getRequestURI().getRawQuery();
             Map<String, String> queryMap = Server.queryToMap(query);
             String canvasId = queryMap.get("id");
 

--- a/back-end/src/main/java/server/ProjectRequestHandler.java
+++ b/back-end/src/main/java/server/ProjectRequestHandler.java
@@ -26,6 +26,10 @@ public class ProjectRequestHandler implements HttpHandler {
         gson = new GsonBuilder().create();
     };
 
+    public static void clearProjectHistoryDueToException(String projectName) {
+        projects.remove(projectName);
+    }
+
     private Project getLastProjectObject(String projectName) {
 
         if (!projects.containsKey(projectName)) return null;

--- a/back-end/src/main/java/server/ProjectRequestHandler.java
+++ b/back-end/src/main/java/server/ProjectRequestHandler.java
@@ -26,7 +26,7 @@ public class ProjectRequestHandler implements HttpHandler {
         gson = new GsonBuilder().create();
     };
 
-    public static void clearProjectHistoryDueToException(String projectName) {
+    public static void clearProjectHistory(String projectName) {
         projects.remove(projectName);
     }
 

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -55,7 +55,7 @@ public class Server {
             printIndexingErrorMessage();
 
             // clear project history and set current project to null
-            ProjectRequestHandler.clearProjectHistoryDueToException(Main.getProject().getName());
+            ProjectRequestHandler.clearProjectHistory(Main.getProject().getName());
             Main.setProject(null);
 
             // close db connections

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -47,10 +47,18 @@ public class Server {
             Main.setProjectClean();
             System.out.println("Completed recomputing indexes. Server restarting...");
         } catch (Exception e) {
+            // print out stack trace
             e.printStackTrace();
             System.out.println("\n\n" + e.getMessage() + "\n");
+
+            // print out indexing error message
             printIndexingErrorMessage();
+
+            // clear project history and set current project to null
+            ProjectRequestHandler.clearProjectHistoryDueToException(Main.getProject().getName());
             Main.setProject(null);
+
+            // close db connections
             DbConnector.closeAllConnections();
             System.out.println("Server restarting....");
         }

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -5,6 +5,7 @@ import com.sun.net.httpserver.HttpServer;
 import index.Indexer;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
@@ -148,15 +149,17 @@ public class Server {
     }
 
     // https://stackoverflow.com/questions/11640025/how-to-obtain-the-query-string-in-a-get-with-java-httpserver-httpexchange
-    public static Map<String, String> queryToMap(String query) {
+    public static Map<String, String> queryToMap(String query) throws UnsupportedEncodingException {
 
         Map<String, String> result = new HashMap<>();
         // check if query is null
         if (query == null) return result;
         for (String param : query.split("&")) {
+            param = java.net.URLDecoder.decode(param, "UTF-8");
             int pos = param.indexOf("=");
             result.put(param.substring(0, pos), param.substring(pos + 1));
         }
+
         return result;
     }
 

--- a/compiler/examples/USMap/USMap.js
+++ b/compiler/examples/USMap/USMap.js
@@ -62,7 +62,11 @@ countyMapStateBoundaryLayer.addRenderingFunc(
 var countyBoundaryLayer = new Layer(transforms.countyMapTransform, false);
 countyMapCanvas.addLayer(countyBoundaryLayer);
 countyBoundaryLayer.addPlacement(placements.countyMapPlacement);
-countyBoundaryLayer.addRenderingFunc(renderers.countyMapRendering);
+countyBoundaryLayer.addRenderingFunc(
+    renderers.countyMapRendering,
+    ["name", "crimerate"],
+    ["County", "Crime Rate"]
+);
 
 // ================== Views ===================
 var view = new View("usmap", 0, 0, stateMapWidth, stateMapHeight);

--- a/compiler/examples/USMap/renderers.js
+++ b/compiler/examples/USMap/renderers.js
@@ -237,36 +237,6 @@ var countyMapRendering = function(svg, data, args) {
         .style("stroke-width", "0.5")
         .style("fill", function(d) {
             return color(d.crimerate);
-        })
-        .on("mouseover", function(d, i) {
-            // remove all tool tips first
-            d3.select("body")
-                .selectAll(".countymaptooltip")
-                .remove();
-            // create a new tooltip
-            var tooltip = d3
-                .select("body")
-                .append("div")
-                .attr("id", "countyMapTooltip" + i)
-                .classed("countymaptooltip", true)
-                .style("position", "absolute")
-                .style("width", "200px")
-                .style("height", "28px")
-                .style("pointer-events", "none")
-                .style("opacity", 0)
-                .style("font-size", "23px")
-                .style("color", "rgb(134, 142, 112)");
-            tooltip
-                .transition()
-                .duration(200)
-                .style("opacity", 0.9);
-            tooltip
-                .html(d.name + "\n" + d.crimerate)
-                .style("left", d3.event.pageX + "px")
-                .style("top", d3.event.pageY + "px");
-        })
-        .on("mouseout", function(d, i) {
-            d3.select("#countyMapTooltip" + i).remove();
         });
 };
 

--- a/compiler/examples/USMap_cmv/USMap_cmv.js
+++ b/compiler/examples/USMap_cmv/USMap_cmv.js
@@ -71,7 +71,7 @@ p.setInitialStates(view, stateMapCanvas, 0, 0);
 
 var rightView = new View(
     "county",
-    stateMapWidth + 100,
+    stateMapWidth + 150,
     0,
     stateMapWidth,
     stateMapHeight

--- a/compiler/src/Layer.js
+++ b/compiler/src/Layer.js
@@ -52,7 +52,7 @@ function addPlacement(placement) {
  * add a rendering function to a layer object
  * @param rendering - a javascript function that adds an <g> element to an existing svg. See spec api for details on input/output.
  * @param tooltipColumns - an array of column names to be displayed in the tooltip
- * @param tooltipAliases - an array of alias to tooltipColumns
+ * @param tooltipAliases - an array of aliases to tooltipColumns
  */
 function addRenderingFunc(rendering, tooltipColumns, tooltipAliases) {
     if (typeof rendering !== "function")

--- a/compiler/src/Layer.js
+++ b/compiler/src/Layer.js
@@ -51,14 +51,19 @@ function addPlacement(placement) {
 /**
  * add a rendering function to a layer object
  * @param rendering - a javascript function that adds an <g> element to an existing svg. See spec api for details on input/output.
+ * @param tooltipColumns - an array of column names to be displayed in the tooltip
+ * @param tooltipAliases - an array of alias to tooltipColumns
  */
-function addRenderingFunc(rendering) {
+function addRenderingFunc(rendering, tooltipColumns, tooltipAliases) {
     if (typeof rendering !== "function")
         throw new Error(
             "Constructing Layer: rendering must be a javascript function."
         );
 
     this.rendering = rendering;
+    this.tooltipColumns = tooltipColumns == null ? [] : tooltipColumns;
+    this.tooltipAliases =
+        tooltipAliases == null ? tooltipColumns : tooltipAliases;
 }
 
 function setFetchingScheme(fetchingScheme, deltaBox) {

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -334,7 +334,9 @@ function addAutoDD(autoDD, args) {
 
         // construct rendering function
         curLayer.addRenderingFunc(
-            autoDD.getLayerRenderer(i, this.autoDDs.length - 1)
+            autoDD.getLayerRenderer(i, this.autoDDs.length - 1),
+            autoDD.tooltipColumns,
+            autoDD.tooltipAliases
         );
 
         // axes

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -264,9 +264,7 @@ function addAutoDD(autoDD, args) {
 
     // add stuff to renderingParam
     this.addRenderingParams({
-        textwrap: require("./template-api/Utilities").textwrap,
-        toLargeNumberNotation: require("./template-api/Utilities")
-            .toLargeNumberNotation
+        textwrap: require("./template-api/Utilities").textwrap
     });
     this.addRenderingParams({fadeInDuration: 200});
     this.addRenderingParams(autoDD.clusterParams);

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -1476,9 +1476,14 @@ function getAxesRenderer(level) {
         var styling = function(axesg) {
             axesg
                 .selectAll(".tick line")
-                .attr("stroke", "#777")
-                .attr("stroke-dasharray", "3,10");
-            axesg.style("font", "20px arial");
+                .attr("stroke", "#CCC")
+                .attr("stroke-dasharray", "5, 5")
+                .style("opacity", 0.3);
+            axesg.style("font", "16px arial");
+            axesg
+                .selectAll("g")
+                .selectAll("text")
+                .style("fill", "#999");
             axesg.selectAll("path").remove();
         };
         //x
@@ -1494,7 +1499,10 @@ function getAxesRenderer(level) {
             .scaleTime()
             .domain([stDate, enDate])
             .range([REPLACE_ME_xOffset, cWidth - REPLACE_ME_xOffset]);*/
-        var xAxis = d3.axisBottom().tickSize(-cHeight);
+        var xAxis = d3
+            .axisBottom()
+            .tickSize(-cHeight)
+            .tickFormat(d3.format("~s"));
         axes.push({
             dim: "x",
             scale: x,
@@ -1507,7 +1515,10 @@ function getAxesRenderer(level) {
             .scaleLinear()
             .domain([REPLACE_ME_this_loY, REPLACE_ME_this_hiY])
             .range([REPLACE_ME_yOffset, cHeight - REPLACE_ME_yOffset]);
-        var yAxis = d3.axisLeft().tickSize(-cWidth);
+        var yAxis = d3
+            .axisLeft()
+            .tickSize(-cWidth)
+            .tickFormat(d3.format("~s"));
         axes.push({
             dim: "y",
             scale: y,

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -293,10 +293,8 @@ function AutoDD(args) {
      ************************/
     this.clusterParams =
         "config" in args.marks.cluster ? args.marks.cluster.config : {};
-    // precision parameters
     setPropertiesIfNotExists(this.clusterParams, {
-        precisionDecimal0: 1,
-        precisionDecimal1: 0
+        numberFormat: "~s"
     });
     if (args.marks.cluster.mode == "circle")
         setPropertiesIfNotExists(this.clusterParams, {
@@ -564,11 +562,7 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .append("text")
             .attr("dy", "0.3em")
             .text(function(d) {
-                return params.toLargeNumberNotation(
-                    +d.clusterAgg[agg],
-                    params.precisionDecimal0,
-                    params.precisionDecimal1
-                );
+                return d3.format(params.numberFormat)(+d.clusterAgg[agg]);
             })
             .attr("font-size", function(d) {
                 return circleSizeInterpolator(d.clusterAgg[agg]) / 2;
@@ -613,11 +607,9 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .enter()
             .append("text")
             .text(function(d) {
-                return args.renderingParams.toLargeNumberNotation(
-                    +d.clusterAgg["count(*)"],
-                    params.precisionDecimal0,
-                    params.precisionDecimal1
-                );
+                return d3.format(
+                    params.numberFormat
+                )(+d.clusterAgg["count(*)"]);
             })
             .attr("x", function(d) {
                 return +d.cx;
@@ -1010,11 +1002,9 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             d3.select(nodes[j])
                 .append("text")
                 .text(function(d) {
-                    return params.toLargeNumberNotation(
-                        d.clusterAgg["count(*)"],
-                        params.precisionDecimal0,
-                        params.precisionDecimal1
-                    );
+                    return d3.format(
+                        params.numberFormat
+                    )(d.clusterAgg["count(*)"]);
                 })
                 .attr("font-size", 25)
                 .attr("x", function(d) {
@@ -1133,11 +1123,7 @@ function getLayerRenderer(level, autoDDArrayIndex) {
             .append("text")
             .classed("cluster_num", true)
             .text(d =>
-                params.toLargeNumberNotation(
-                    +d.clusterAgg["count(*)"],
-                    params.precisionDecimal0,
-                    params.precisionDecimal1
-                )
+                d3.format(params.numberFormat)(+d.clusterAgg["count(*)"])
             )
             .attr("x", d => +d.cx)
             .attr("y", d => +d.cy - params.pieOuterRadius)
@@ -1280,10 +1266,8 @@ function getLayerRenderer(level, autoDDArrayIndex) {
                 var maxlen = 0;
                 for (var j = 0; j < data.length; j++) {
                     if (!isNaN(data[j][fields[i]]))
-                        data[j][fields[i]] = params.toLargeNumberNotation(
-                            +data[j][fields[i]],
-                            params.precisionDecimal0,
-                            params.precisionDecimal1
+                        data[j][fields[i]] = d3.format(params.numberFormat)(
+                            +data[j][fields[i]]
                         );
                     maxlen = Math.max(
                         maxlen,

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -470,6 +470,10 @@ function AutoDD(args) {
             ? 0
             : 1;
     this.axis = "axis" in args.config ? args.config.axis : false;
+    this.xAxisTitle =
+        "xAxisTitle" in args.config ? args.config.xAxisTitle : this.xCol;
+    this.yAxisTitle =
+        "yAxisTitle" in args.config ? args.config.yAxisTitle : this.yCol;
     this.loX = args.layout.x.extent != null ? args.layout.x.extent[0] : null;
     this.loY = args.layout.y.extent != null ? args.layout.y.extent[0] : null;
     this.hiX = args.layout.x.extent != null ? args.layout.x.extent[1] : null;
@@ -1473,18 +1477,40 @@ function getAxesRenderer(level) {
         var cWidth = args.canvasW,
             cHeight = args.canvasH,
             axes = [];
-        var styling = function(axesg) {
+        var styling = function(axesg, dim, id, args) {
             axesg
                 .selectAll(".tick line")
                 .attr("stroke", "#CCC")
                 .attr("stroke-dasharray", "5, 5")
                 .style("opacity", 0.3);
-            axesg.style("font", "16px arial");
+            axesg.attr("font-family", "Open Sans").attr("font-size", "13");
             axesg
                 .selectAll("g")
                 .selectAll("text")
                 .style("fill", "#999");
             axesg.selectAll("path").remove();
+            xAxisTitle = "REPLACE_ME_X_TITLE";
+            yAxisTitle = "REPLACE_ME_Y_TITLE";
+            if (dim == "x")
+                axesg
+                    .append("text")
+                    .text(xAxisTitle)
+                    .attr("fill", "black")
+                    .attr("text-anchor", "middle")
+                    .attr(
+                        "transform",
+                        "translate(" + args.viewportW / 2 + ", 40)"
+                    );
+            else
+                axesg
+                    .append("text")
+                    .text(yAxisTitle)
+                    .attr("fill", "black")
+                    .attr("text-anchor", "middle")
+                    .attr(
+                        "transform",
+                        "translate(-60, " + args.viewportH / 2 + ") rotate(-90)"
+                    );
         };
         //x
         var x = d3
@@ -1510,6 +1536,7 @@ function getAxesRenderer(level) {
             translate: [0, args.viewportH],
             styling: styling
         });
+
         //y
         var y = d3
             .scaleLinear()
@@ -1538,7 +1565,9 @@ function getAxesRenderer(level) {
         .replace(/REPLACE_ME_this_loY/g, this.loY)
         .replace(/REPLACE_ME_this_hiY/g, this.hiY)
         .replace(/REPLACE_ME_xOffset/g, xOffset)
-        .replace(/REPLACE_ME_yOffset/g, yOffset);
+        .replace(/REPLACE_ME_yOffset/g, yOffset)
+        .replace(/REPLACE_ME_X_TITLE/g, this.xAxisTitle)
+        .replace(/REPLACE_ME_Y_TITLE/g, this.yAxisTitle);
     return new Function("args", axesFuncBody);
 }
 

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -227,6 +227,10 @@ function AutoDD(args) {
             "Constructing AutoDD: there must be exactly 1 aggregate measure for pie charts."
         );
     if ("rankList" in args.marks.hover) {
+        if ("tooltip" in args.marks.hover)
+            throw new Error(
+                "Constructing AutoDD: rankList and tooltip cannot be specified together."
+            );
         if (!("mode" in args.marks.hover.rankList))
             throw new Error(
                 "Constructing AutoDD: hover rankList mode (marks.hover.rankList.mode) is missing."
@@ -266,6 +270,23 @@ function AutoDD(args) {
                 "Constructing AutoDD: unrecognized hover boundary type " +
                     args.marks.hover.boundary
             );
+    if ("tooltip" in args.marks.hover) {
+        if (!("columns" in args.marks.hover.tooltip))
+            throw new Error(
+                "Constructing AutoDD: tooltip columns (marks.hover.tooltip.columns) missing."
+            );
+        if (!Array.isArray(args.marks.hover.tooltip.columns))
+            throw new Error(
+                "Constructing AutoDD: tooltip columns (marks.hover.tooltip.columns) must be an array."
+            );
+        if (
+            "aliases" in args.marks.hover.tooltip &&
+            !Array.isArray(args.marks.hover.tooltip.aliases)
+        )
+            throw new Error(
+                "Constructing AutoDD: tooltip aliases (marks.hover.tooltip.aliases) must be an array."
+            );
+    }
 
     /************************
      * setting cluster params
@@ -391,6 +412,13 @@ function AutoDD(args) {
     if ("boundary" in args.marks.hover)
         this.hoverParams.hoverBoundary = args.marks.hover.boundary;
     this.topk = this.hoverParams.topk != null ? this.hoverParams.topk : 0;
+    this.tooltipColumns = this.tooltipAliases = null;
+    if ("tooltip" in args.marks.hover) {
+        this.tooltipColumns = args.marks.hover.tooltip.columns;
+        if ("aliases" in args.marks.hover.tooltip)
+            this.tooltipAliases = args.marks.hover.tooltip.aliases;
+        else this.tooltipAliases = this.tooltipColumns;
+    }
 
     /***************************
      * setting legend parameters

--- a/compiler/src/template-api/AutoDD.js
+++ b/compiler/src/template-api/AutoDD.js
@@ -294,7 +294,7 @@ function AutoDD(args) {
     this.clusterParams =
         "config" in args.marks.cluster ? args.marks.cluster.config : {};
     setPropertiesIfNotExists(this.clusterParams, {
-        numberFormat: "~s"
+        numberFormat: ".2~s"
     });
     if (args.marks.cluster.mode == "circle")
         setPropertiesIfNotExists(this.clusterParams, {

--- a/compiler/src/template-api/Utilities.js
+++ b/compiler/src/template-api/Utilities.js
@@ -194,39 +194,11 @@ function serializePath(path) {
     }, "");
 }
 
-/**
- * Convert a big number to K, Million, Billion notation
- * @param ct
- * @returns {*}
- */
-function toLargeNumberNotation(ct, d0 = 1, d1 = 0) {
-    // d0 is the number of decimals for ct < 1000
-    // d1 is the number of decimals for ct > 1000
-    if (ct < 1000)
-        return (
-            Math.round((ct + Number.EPSILON) * Math.pow(10, d0)) /
-            Math.pow(10, d0)
-        );
-    if (ct >= 1000 && ct < 1000000) {
-        ct /= 1000.0;
-        return ct.toFixed(d1) + "K";
-    }
-    if (ct > 1000000 && ct < 1000000000) {
-        ct /= 1000000.0;
-        return ct.toFixed(d1) + "M";
-    } else {
-        ct /= 1000000000.0;
-        return ct.toFixed(d1) + "B";
-    }
-    return "";
-}
-
 module.exports = {
     textwrap,
     getBodyStringOfFunction,
     setPropertiesIfNotExists,
     parsePathIntoSegments,
     translatePathSegments,
-    serializePath,
-    toLargeNumberNotation
+    serializePath
 };

--- a/compiler/src/template-api/Utilities.js
+++ b/compiler/src/template-api/Utilities.js
@@ -13,7 +13,7 @@ function textwrap(text, width) {
         var text = d3.select(this),
             words = text
                 .text()
-                .split(/(?=[A-Z])/)
+                .split(/\s+/)
                 .reverse(),
             word,
             line = [],
@@ -32,14 +32,14 @@ function textwrap(text, width) {
                     .attr("x", x)
                     .attr("y", y);
             line.push(word);
-            tspan.text(line.join(""));
+            tspan.text(line.join(" "));
             if (tspan.node().getComputedTextLength() > width) {
                 var popped = false;
                 if (line.length > 1) {
                     line.pop();
                     popped = true;
                 }
-                tspan.text(line.join(""));
+                tspan.text(line.join(" "));
                 if (popped) {
                     line = [word];
                     tspan = text

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -11,6 +11,10 @@
             href="https://fonts.googleapis.com/css?family=Source Serif Pro"
             rel="stylesheet"
         />
+        <link
+            href="https://fonts.googleapis.com/css?family=Open+Sans"
+            rel="stylesheet"
+        />
         <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/gpu.js@2.0.0-rc.19/dist/gpu-browser.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.17.0/dist/jquery.validate.min.js"></script>

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -273,6 +273,14 @@ function renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs) {
                     );
                     tileSvg.style("opacity", 1.0);
 
+                    // tooltip
+                    if (curLayer.tooltipColumns.length > 0)
+                        makeTooltips(
+                            tileSvg.selectAll("*"),
+                            curLayer.tooltipColunms,
+                            curLayer.tooltipAliases
+                        );
+
                     // register jumps
                     if (!gvd.animation) registerJumps(viewId, tileSvg, i);
 
@@ -480,6 +488,14 @@ function renderDynamicBoxes(
                         renderData[i],
                         optionalArgsWithBoxWHXY
                     );
+
+                    // tooltip
+                    if (curLayer.tooltipColumns.length > 0)
+                        makeTooltips(
+                            dboxSvg.select("g:last-of-type").selectAll("*"),
+                            curLayer.tooltipColunms,
+                            curLayer.tooltipAliases
+                        );
 
                     // register jumps
                     if (!gvd.animation) registerJumps(viewId, dboxSvg, i);

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -274,7 +274,7 @@ function renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs) {
                     tileSvg.style("opacity", 1.0);
 
                     // register jumps
-                    if (!globalVar.animation) registerJumps(viewId, tileSvg, i);
+                    if (!gvd.animation) registerJumps(viewId, tileSvg, i);
 
                     // highlight
                     highlightLowestSvg(viewId, tileSvg, i);

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -277,7 +277,7 @@ function renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs) {
                     if (curLayer.tooltipColumns.length > 0)
                         makeTooltips(
                             tileSvg.selectAll("*"),
-                            curLayer.tooltipColunms,
+                            curLayer.tooltipColumns,
                             curLayer.tooltipAliases
                         );
 
@@ -493,7 +493,7 @@ function renderDynamicBoxes(
                     if (curLayer.tooltipColumns.length > 0)
                         makeTooltips(
                             dboxSvg.select("g:last-of-type").selectAll("*"),
-                            curLayer.tooltipColunms,
+                            curLayer.tooltipColumns,
                             curLayer.tooltipAliases
                         );
 

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -10,7 +10,8 @@ function renderAxes(viewId, viewportX, viewportY, vWidth, vHeight) {
     var axesFunc = gvd.curCanvas.axes;
     if (axesFunc == "") return;
 
-    var axes = axesFunc.parseFunction()(getOptionalArgs(viewId));
+    var args = getOptionalArgs(viewId);
+    var axes = axesFunc.parseFunction()(args);
     for (var i = 0; i < axes.length; i++) {
         // create g element
         var curg = axesg
@@ -59,7 +60,7 @@ function renderAxes(viewId, viewportX, viewportY, vWidth, vHeight) {
         curg.call(axes[i].axis.scale(newScale));
 
         // styling
-        if ("styling" in axes[i]) axes[i].styling(curg);
+        if ("styling" in axes[i]) axes[i].styling(curg, axes[i].dim, i, args);
     }
 }
 

--- a/front-end/js/globalVar.js
+++ b/front-end/js/globalVar.js
@@ -53,7 +53,14 @@ function getOptionalArgs(viewId) {
 
 // get SQL predicates from a predicate dictionary
 function getSqlPredicate(p) {
-    if ("==" in p) return "(" + p["=="][0] + "='" + p["=="][1] + "')";
+    if ("==" in p)
+        return (
+            "(" +
+            p["=="][0].replace(/&/g, "%26") +
+            "='" +
+            p["=="][1].replace(/&/g, "%26") +
+            "')"
+        );
     if ("AND" in p)
         return (
             "(" +
@@ -143,7 +150,7 @@ function makeTooltips(selection, columns, aliases) {
 
         // column values
         rows.append("td")
-            .html(p => (!isNaN(d[p]) ? d3.format(".2f")(d[p]) : d[p]))
+            .html(p => (!isNaN(d[p]) ? d3.format(",.2f")(d[p]) : d[p]))
             .style("font-weight", "900")
             .style("padding-left", "2px")
             .style("padding-right", "10px")

--- a/front-end/js/globalVar.js
+++ b/front-end/js/globalVar.js
@@ -114,7 +114,7 @@ function getJumpsByCanvasId(canvasId) {
 // make tooltips after rendering functions are called
 function makeTooltips(selection, columns, aliases) {
     var createTooltip = function(d) {
-        if (d == null) return;
+        if (d == null || typeof d !== "object") return;
         // remove all tool tips first
         d3.select("body")
             .selectAll(".kyrixtooltip")
@@ -169,13 +169,13 @@ function makeTooltips(selection, columns, aliases) {
     selection
         .on("mouseover", d => createTooltip(d))
         .on("mousemove", function(d) {
-            if (d == null) return;
+            if (d == null || typeof d !== "object") return;
             d3.select(".kyrixtooltip")
                 .style("left", d3.event.pageX + "px")
                 .style("top", d3.event.pageY + "px");
         })
         .on("mouseout", function(d) {
-            if (d == null) return;
+            if (d == null || typeof d !== "object") return;
             d3.select(".kyrixtooltip").remove();
         });
 }

--- a/front-end/js/globalVar.js
+++ b/front-end/js/globalVar.js
@@ -56,9 +56,9 @@ function getSqlPredicate(p) {
     if ("==" in p)
         return (
             "(" +
-            p["=="][0].replace(/&/g, "%26") +
+            p["=="][0].toString().replace(/&/g, "%26") +
             "='" +
-            p["=="][1].replace(/&/g, "%26") +
+            p["=="][1].toString().replace(/&/g, "%26") +
             "')"
         );
     if ("AND" in p)

--- a/front-end/js/globalVar.js
+++ b/front-end/js/globalVar.js
@@ -103,3 +103,72 @@ function getJumpsByCanvasId(canvasId) {
 
     return jumps;
 }
+
+// make tooltips after rendering functions are called
+function makeTooltips(selection, columns, aliases) {
+    var createTooltip = function(d) {
+        if (d == null) return;
+        // remove all tool tips first
+        d3.select("body")
+            .selectAll(".kyrixtooltip")
+            .remove();
+        // create a new tooltip
+        var tooltip = d3
+            .select("body")
+            .append("table")
+            .classed("kyrixtooltip", true)
+            .style("background", "#FFF")
+            .style("border-radius", "3px")
+            .style("position", "absolute")
+            .style("box-shadow", "2px 2px #888888")
+            .style("pointer-events", "none")
+            .style("opacity", 0)
+            .style("font-size", "13px")
+            .style("font-family", "Open Sans")
+            .style("left", d3.event.pageX + "px")
+            .style("top", d3.event.pageY + "px");
+        var rows = tooltip
+            .selectAll(".kyrix-tooltip-rows")
+            .data(columns)
+            .join("tr");
+        // column names
+        rows.append("td")
+            .html((p, j) => aliases[j] + ":")
+            .style("padding-left", "10px")
+            .style("padding-right", "2px")
+            .style("padding-top", (p, i) => (i == 0 ? "10px" : "1px"))
+            .style("padding-bottom", (p, i) =>
+                i == columns.length - 1 ? "10px" : "1px"
+            );
+
+        // column values
+        rows.append("td")
+            .html(p => (!isNaN(d[p]) ? d3.format(".2f")(d[p]) : d[p]))
+            .style("font-weight", "900")
+            .style("padding-left", "2px")
+            .style("padding-right", "10px")
+            .style("padding-top", (p, i) => (i == 0 ? "10px" : "1px"))
+            .style("padding-bottom", (p, i) =>
+                i == columns.length - 1 ? "10px" : "1px"
+            );
+
+        // fade in
+        tooltip
+            .transition()
+            .duration(200)
+            .style("opacity", 0.9);
+    };
+
+    selection
+        .on("mouseover", d => createTooltip(d))
+        .on("mousemove", function(d) {
+            if (d == null) return;
+            d3.select(".kyrixtooltip")
+                .style("left", d3.event.pageX + "px")
+                .style("top", d3.event.pageY + "px");
+        })
+        .on("mouseout", function(d) {
+            if (d == null) return;
+            d3.select(".kyrixtooltip").remove();
+        });
+}

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -47,6 +47,7 @@ function preJump(viewId, zoomType) {
     d3.selectAll("button" + viewClass).attr("disabled", true);
 
     gvd.animation = zoomType;
+    gvd.initialScale = null;
 }
 
 function postJump(viewId, zoomType) {
@@ -67,9 +68,7 @@ function postJump(viewId, zoomType) {
         // in the future we shouldn't need these if-elses
         // gvd.initialScale should be set prior to all jumps.
         // relevant: https://github.com/tracyhenry/Kyrix/issues/12
-        else if (zoomType == param.load)
-            setupZoom(viewId, gvd.initialScale || 1);
-        else setupZoom(viewId, 1);
+        else setupZoom(viewId, gvd.initialScale || 1);
 
         // set up button states
         setBackButtonState(viewId);
@@ -322,9 +321,10 @@ function semanticZoom(viewId, jump, predArray, newVpX, newVpY, tuple) {
         // change viewBox of static layers
         minx = v[0] - vWidth / 2.0;
         miny = v[1] - vHeight / 2.0;
+        var k = gvd.viewportWidth / curViewport[2];
         d3.selectAll(viewClass + ".oldmainsvg.static").attr(
             "viewBox",
-            minx + " " + miny + " " + vWidth + " " + vHeight
+            minx * k + " " + miny * k + " " + vWidth * k + " " + vHeight * k
         );
 
         // change opacity

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -273,6 +273,7 @@ function semanticZoom(viewId, jump, predArray, newVpX, newVpY, tuple) {
                 zoomAndFade(t, i(t));
             };
         })
+        .ease(d3.easeSinOut)
         .on("start", function() {
             // schedule a new entering transition
             if (enteringAnimation)

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -1,11 +1,11 @@
 function removePopovers(viewId) {
-    var selector = ".popover";
+    var selector = ".popover,.kyrixtooltip";
     if (viewId != null) selector += ".view_" + viewId;
     d3.selectAll(selector).remove();
 }
 
 function removePopoversSmooth(viewId) {
-    var selector = ".popover";
+    var selector = ".popover,.kyrixtooltip";
     if (viewId != null) selector += ".view_" + viewId;
     d3.selectAll(selector)
         .transition()
@@ -43,7 +43,10 @@ function preJump(viewId, zoomType) {
     d3.select(viewClass + ".viewsvg")
         .selectAll("*")
         .style("cursor", "auto")
-        .on("click", null);
+        .on("click", null)
+        .on("mouseover", null)
+        .on("mouseout", null)
+        .on("mousemove", null);
     d3.selectAll("button" + viewClass).attr("disabled", true);
 
     gvd.animation = zoomType;
@@ -209,6 +212,13 @@ function semanticZoom(viewId, jump, predArray, newVpX, newVpY, tuple) {
             .split(" ");
     for (var i = 0; i < curViewport.length; i++)
         curViewport[i] = +curViewport[i];
+    if (
+        !("minx" in tuple) ||
+        !("miny" in tuple) ||
+        !("maxx" in tuple) ||
+        !("maxy" in tuple)
+    )
+        tuple.minx = tuple.miny = tuple.maxx = tuple.maxy = 0;
     var tupleWidth = +tuple.maxx - tuple.minx;
     var tupleHeight = +tuple.maxy - tuple.miny;
     var minx, maxx, miny, maxy;

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -36,7 +36,7 @@ param.dimOpacity = 0.4;
 param.extraTiles = 0;
 
 // padding for the container svg
-param.viewPadding = 50;
+param.viewPadding = 100;
 
 // jump types
 param.literalZoomIn = "literal_zoom_in";

--- a/front-end/js/staticLayers.js
+++ b/front-end/js/staticLayers.js
@@ -22,6 +22,14 @@ function renderStaticLayers(viewId) {
         var curSvg = d3.select(viewClass + ".layerg.layer" + i).select("svg");
         renderFunc(curSvg, gvd.curStaticData[i], getOptionalArgs(viewId));
 
+        // tooltips
+        if (curLayer.tooltipColumns.length > 0)
+            makeTooltips(
+                curSvg.selectAll("*"),
+                curLayer.tooltipColumns,
+                curLayer.tooltipAliases
+            );
+
         // register jump
         if (!gvd.animation) registerJumps(viewId, curSvg, i);
 

--- a/front-end/js/zoom.js
+++ b/front-end/js/zoom.js
@@ -4,9 +4,11 @@ function zoomRescale(viewId, ele, oldGScaleX, oldGScaleY) {
 
     var cx = d3.select(ele).datum().cx;
     var cy = d3.select(ele).datum().cy; // finding center of element
-    var transform = d3.zoomTransform(d3.select(viewClass + ".maing").node());
-    var scaleX = 1 / transform.k;
-    var scaleY = 1 / transform.k;
+    var k = gvd.initialScale || 1;
+    if (!gvd.animation)
+        k = d3.zoomTransform(d3.select(viewClass + ".maing").node()).k;
+    var scaleX = 1 / k;
+    var scaleY = 1 / k;
 
     if (gvd.curCanvas.zoomInFactorX <= 1 && gvd.curCanvas.zoomOutFactorX >= 1)
         scaleX = 1;

--- a/front-end/js/zoomButton.js
+++ b/front-end/js/zoomButton.js
@@ -171,6 +171,7 @@ function backspace(viewId) {
                     enterAndZoom(t, i(t));
                 };
             })
+            .ease(d3.easeSinIn)
             .on("start", function() {
                 // set up layer layouts
                 setupLayerLayouts(viewId);

--- a/front-end/js/zoomButton.js
+++ b/front-end/js/zoomButton.js
@@ -76,6 +76,9 @@ function logHistory(viewId, zoom_type) {
     curHistory.canvasObj = gvd.curCanvas;
     curHistory.jumps = gvd.curJump;
     curHistory.staticData = gvd.curStaticData;
+    curHistory.initialScale = d3.zoomTransform(
+        d3.select(viewClass + ".maing").node()
+    ).k;
 
     // save current viewport
     var curViewport = [0, 0, gvd.viewportWidth, gvd.viewportHeight];
@@ -116,6 +119,7 @@ function backspace(viewId) {
     gvd.highlightPredicates = curHistory.highlightPredicates;
     gvd.initialViewportX = curHistory.viewportX;
     gvd.initialViewportY = curHistory.viewportY;
+    gvd.initialScale = curHistory.initialScale;
 
     // get current viewport
     var curViewport = [0, 0, gvd.viewportWidth, gvd.viewportHeight];
@@ -201,9 +205,10 @@ function backspace(viewId) {
         // change viewBox of static layers
         minx = v[0] - vWidth / 2.0;
         miny = v[1] - vHeight / 2.0;
+        var k = gvd.initialScale || 1;
         d3.selectAll(viewClass + ".mainsvg.static").attr(
             "viewBox",
-            minx + " " + miny + " " + vWidth + " " + vHeight
+            minx * k + " " + miny * k + " " + vWidth * k + " " + vHeight * k
         );
 
         // change opacity
@@ -229,6 +234,7 @@ function backspace(viewId) {
         var miny = +curViewport[1] + gvd.viewportHeight / 2.0 - vHeight / 2.0;
 
         // change viewBox of old dynamic layers
+        // TODO: this'll probably fail when zooming back from a literal zoom canvas
         d3.selectAll(viewClass + ".oldmainsvg:not(.static)").attr(
             "viewBox",
             minx + " " + miny + " " + vWidth + " " + vHeight


### PR DESCRIPTION
summary of changes:
* add more arguments to the axes styling function to enable specification of axes titles
* automatic SSV axes with good looking `Open Sans` font
* fixed a bug that jumping from literal-zoomed canvases isn't working
* allowed specification of tooltip columns in `addRenderingFunc`, much easier tooltipping!
* simplified part of the USMap app using the tooltip API
* handled ampersands in predicate values 
* better semantic easing function (`d3.easeSin`) for objects located in corners of the viewport
* clear history of a particular project when there is an exception in indexing (otherwise the history would cause kyrix to believe indexing is not needed upon future project requests). 
* SSV grammar: new `marks.cluster.hover.tooltip` section, using tooltip API
* replaced `toLargeNumberNotation` with d3-format