### PR TITLE
bug fix laundry list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We are working with users from MGH ([30T data vis demo](https://youtu.be/fZ32cE8
 
 ## Installation instructions for the impatient
 
-1. Install Docker (e.g. on a Linux system run `sudo apt update; sudo apt install -y docker.io docker-compose;`). 
+1. Install [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) (must be `v1.17.0` or later). For Mac users, installing [Docker Desktop](https://docs.docker.com/docker-for-mac/install/) will install Docker Compose automatically. Ubuntu 18.04 users can also simply install with `sudo apt update; sudo apt install -y docker.io docker-compose;`.
 2. Run `sudo ./run-kyrix.sh --nba` in the root directory. You might need to make `run-kyrix.sh` executable, i.e. `sudo chmod +x run-kyrix.sh`.  
 3. Wait a couple minutes, then point your browser at <ip address>:8000 - remember that if you are using a cloud instance you may (probably) need to open your cloud provider's firewall for this port. If that sounds scary, you can create an SSH tunnel from your PC (e.g. Mac) using `ssh -N <server ipaddr> -L 8000:<same ipaddr>:8000` to forward your laptop's port 8000 to the server via [SSH tunneling](https://www.tecmint.com/create-ssh-tunneling-port-forwarding-in-linux/). 
 

--- a/back-end/src/main/java/box/BoxandData.java
+++ b/back-end/src/main/java/box/BoxandData.java
@@ -1,5 +1,6 @@
 package box;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import project.Canvas;
@@ -19,7 +20,8 @@ public class BoxandData {
     // To enable writing rendering functions using field names,
     // we convert it to an array of arrays of dictionaries (hashMap in Java)
     public static ArrayList<ArrayList<HashMap<String, String>>> getDictionaryFromData(
-            ArrayList<ArrayList<ArrayList<String>>> data, Canvas c) {
+            ArrayList<ArrayList<ArrayList<String>>> data, Canvas c)
+            throws SQLException, ClassNotFoundException {
 
         ArrayList<ArrayList<HashMap<String, String>>> ret = new ArrayList<>();
         int numLayers = data.size();

--- a/back-end/src/main/java/index/BoundingBoxIndexer.java
+++ b/back-end/src/main/java/index/BoundingBoxIndexer.java
@@ -7,7 +7,7 @@ import project.Layer;
 public abstract class BoundingBoxIndexer extends Indexer {
 
     @Override
-    public String getStaticDataQuery(Canvas c, int layerId, String predicate) {
+    public String getStaticDataQuery(Canvas c, int layerId, String predicate) throws Exception {
 
         Layer l = c.getLayers().get(layerId);
         // get column list string

--- a/back-end/src/main/java/index/Indexer.java
+++ b/back-end/src/main/java/index/Indexer.java
@@ -48,16 +48,14 @@ public abstract class Indexer implements Serializable {
 
                 // determine indexer for this layer when the indexer is not set in the compiler
                 if (indexer == null) {
-                    if (Config.database == Config.Database.PSQL
-                            || Config.database == Config.Database.CITUS) {
-                        boolean isCitus = (Config.database == Config.Database.CITUS);
+                    if (Config.database == Config.Database.PSQL) {
                         if (Config.indexingScheme == Config.IndexingScheme.POSTGIS_SPATIAL_INDEX)
-                            indexer = PsqlSpatialIndexer.getInstance(isCitus);
+                            indexer = PsqlSpatialIndexer.getInstance();
                         else if (Config.indexingScheme == Config.IndexingScheme.TILE_INDEX)
-                            indexer = PsqlTileIndexer.getInstance(isCitus);
+                            indexer = PsqlTileIndexer.getInstance();
                         else if (Config.indexingScheme
                                 == Config.IndexingScheme.PSQL_NATIVEBOX_INDEX)
-                            indexer = PsqlNativeBoxIndexer.getInstance(isCitus);
+                            indexer = PsqlNativeBoxIndexer.getInstance();
                         // indexer = PsqlPlv8Indexer.getInstance();
                         else if (Config.indexingScheme
                                 == Config.IndexingScheme.PSQL_NATIVECUBE_INDEX)
@@ -67,7 +65,9 @@ public abstract class Indexer implements Serializable {
                                     "Index type "
                                             + Config.indexingScheme.toString()
                                             + " not supported for PSQL.");
-                    } else if (Config.database == Config.Database.MYSQL) {
+                    } else if (Config.database == Config.Database.CITUS)
+                        indexer = PsqlCitusIndexer.getInstance();
+                    else if (Config.database == Config.Database.MYSQL) {
                         if (l.getIndexerType().equals("SSVInMemoryIndexer"))
                             throw new Exception("SSV is not supported by MySQL indexers.");
                         else if (l.getIndexerType().equals("PsqlPredicatedTableIndexer"))

--- a/back-end/src/main/java/index/Indexer.java
+++ b/back-end/src/main/java/index/Indexer.java
@@ -6,6 +6,7 @@ import com.coveo.nashorn_modules.Require;
 import java.io.File;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +33,8 @@ public abstract class Indexer implements Serializable {
     public abstract ArrayList<ArrayList<String>> getDataFromTile(
             Canvas c, int layerId, int minx, int miny, String predicate) throws Exception;
 
-    public abstract String getStaticDataQuery(Canvas c, int layerId, String predicate);
+    public abstract String getStaticDataQuery(Canvas c, int layerId, String predicate)
+            throws Exception;
 
     // associate each layer with a proper indexer
     public static void associateIndexer() throws Exception {
@@ -156,7 +158,8 @@ public abstract class Indexer implements Serializable {
     }
 
     // calculate bounding box indexes for a given row in a given layer
-    protected static ArrayList<Double> getBboxCoordinates(Layer l, ArrayList<String> row) {
+    protected static ArrayList<Double> getBboxCoordinates(Layer l, ArrayList<String> row)
+            throws SQLException, ClassNotFoundException {
 
         // array to return
         ArrayList<Double> bbox = new ArrayList<>();

--- a/back-end/src/main/java/index/PsqlCitusIndexer.java
+++ b/back-end/src/main/java/index/PsqlCitusIndexer.java
@@ -1,0 +1,192 @@
+package index;
+
+import java.sql.Statement;
+import java.util.Date;
+import java.util.function.UnaryOperator;
+import main.Config;
+import main.DbConnector;
+import main.Main;
+import project.Canvas;
+import project.Layer;
+import project.Transform;
+
+/** Created by wenbo on 4/25/20. */
+public class PsqlCitusIndexer extends PsqlNativeBoxIndexer {
+
+    private static PsqlNativeBoxIndexer instance = null;
+
+    // singleton pattern to ensure only one instance existed
+    protected PsqlCitusIndexer() {}
+
+    // thread-safe instance getter
+    public static synchronized PsqlNativeBoxIndexer getInstance() {
+
+        if (instance == null) instance = new PsqlCitusIndexer();
+        return instance;
+    }
+
+    void run_citus_dml_ddl(Statement stmt, String sql) throws Exception {
+        System.out.println(sql + " -- also running on workers");
+        System.out.println(sql.replaceAll("\n", " "));
+        stmt.executeUpdate(sql);
+        sql = "select run_command_on_workers($CITUS$ " + sql + " $CITUS$);";
+        System.out.println(sql.replaceAll("\n", " "));
+        stmt.executeQuery(sql);
+    }
+
+    void run_citus_dml_ddl2(Statement stmt, String masterSql, String workerSql) throws Exception {
+        System.out.println(masterSql.replaceAll("\n", " "));
+        stmt.executeUpdate(masterSql);
+        String dworkerSql = "select run_command_on_workers($CITUS$ " + workerSql + " $CITUS$);";
+        System.out.println(dworkerSql.replaceAll("\n", " "));
+        stmt.executeQuery(dworkerSql);
+    }
+
+    @Override
+    public void createMV(Canvas c, int layerId) throws Exception {
+
+        Layer l = c.getLayers().get(layerId);
+        Transform trans = l.getTransform();
+
+        // step 0: create tables for storing bboxes and tiles
+        String bboxTableName =
+                "bbox_" + Main.getProject().getName() + "_" + c.getId() + "layer" + layerId;
+
+        // drop table if exists
+        Statement dropCreateStmt = DbConnector.getStmtByDbName(Config.databaseName);
+        String sql = "drop table if exists " + bboxTableName + ";";
+        System.out.println(sql);
+        dropCreateStmt.executeUpdate(sql);
+
+        // create the bbox table
+        // yes, citus supports unlogged tables!
+        // http://docs.citusdata.com/en/v8.1/performance/performance_tuning.html#postgresql-tuning
+        sql = "CREATE UNLOGGED TABLE " + bboxTableName + " (";
+        for (int i = 0; i < trans.getColumnNames().size(); i++)
+            sql += trans.getColumnNames().get(i) + " text, ";
+        sql += "citus_distribution_id int, ";
+        sql +=
+                "cx double precision, cy double precision, minx double precision, miny double precision, maxx double precision, maxy double precision, geom box)";
+        System.out.println(sql);
+        dropCreateStmt.executeUpdate(sql);
+        dropCreateStmt.close();
+
+        // if this is an empty layer, return
+        if (trans.getDb().equals("")) return;
+
+        System.out.println(
+                "Transform database marked 'src_db_same_as_kyrix' - trying to pushdown...");
+        Statement pushdownIndexStmt = DbConnector.getStmtByDbName(Config.databaseName);
+
+        String transformFuncName = bboxTableName + "_transform_func";
+        String bboxFuncName = bboxTableName + "_bbox_func";
+        UnaryOperator<String> tsql =
+                (sqlstr) -> {
+                    return (sqlstr.replaceAll("transfunc", transformFuncName)
+                            .replaceAll("bboxfunc", bboxFuncName)
+                            .replaceAll("bboxtbl", bboxTableName)
+                            .replaceAll("dbsource", trans.getDbsource()));
+                };
+
+        // register transform JS function with Postgres/Citus
+        run_citus_dml_ddl(pushdownIndexStmt, tsql.apply("DROP FUNCTION IF EXISTS bboxfunc"));
+        run_citus_dml_ddl(pushdownIndexStmt, tsql.apply("DROP FUNCTION IF EXISTS transfunc"));
+
+        // bbox func
+        sql =
+                tsql.apply(
+                        "CREATE OR REPLACE FUNCTION bboxfunc(v json) returns double precision[]"
+                                + " AS $$ return [v.x, v.y, v.x-0.5, v.y-0.5, (+v.x)+0.5, (+v.y)+0.5]"
+                                + "$$ LANGUAGE plv8");
+        // master needs 'stable' for citus to pushdown to workers
+        // workers need 'volatile' for pg11 to memoize and not call the function repeatedly per
+        // row
+        run_citus_dml_ddl2(
+                pushdownIndexStmt, sql + " STABLE", sql); // append is safer than replace...
+
+        // transform func
+        sql =
+                tsql.apply(
+                        "CREATE OR REPLACE FUNCTION transfunc(obj json, cw int, ch int, params json) returns json"
+                                +
+                                // TODO(security): SQL injection - perhaps use $foo<hard to
+                                // guess number>$ ... $foo<#>$ ?
+                                " AS $$ "
+                                + trans.getTransformFuncBody()
+                                + " $$ LANGUAGE plv8");
+        // master needs 'stable' for citus to pushdown to workers
+        // workers need 'volatile' for pg11 to memoize and not call the function repeatedly per
+        // row
+        run_citus_dml_ddl2(
+                pushdownIndexStmt, sql + " STABLE", sql); // append is safer than replace...
+
+        // by distributing afterwards, loading is ~10x faster (minus a few minutes to distribute
+        // the data)
+        sql =
+                tsql.apply(
+                        "SELECT create_distributed_table('bboxtbl', 'citus_distribution_id',"
+                                + "colocate_with => 'dbsource')");
+        System.out.println(sql);
+        pushdownIndexStmt.executeQuery(sql);
+
+        // run transform func, create bboxtbl
+        sql =
+                tsql.apply(
+                        "INSERT INTO bboxtbl(id,x,y,citus_distribution_id,cx,cy,minx,miny,maxx,maxy) "
+                                + "SELECT id, x, y, citus_distribution_id, "
+                                + "coords[1], coords[2], coords[3], coords[4], coords[5], coords[6] "
+                                + "FROM ("
+                                + "  SELECT (v->>'id') as id, (v->>'x') as x, (v->>'y') as y, "
+                                + "         citus_distribution_id, "
+                                + "         bboxfunc(v) coords"
+                                + "  FROM ("
+                                + "    SELECT transfunc(row_to_json(dbsource),"
+                                + c.getW()
+                                + ","
+                                + c.getH()
+                                + ",\'"
+                                + Main.getProject().getRenderingParams().replaceAll("\'", "\'\'")
+                                + "\'::json) v, citus_distribution_id FROM dbsource"
+                                + "  ) sq1"
+                                + ") sq2");
+        long startts = System.currentTimeMillis();
+        System.out.println("pipeline/insertion: " + sql);
+        pushdownIndexStmt.executeUpdate(sql);
+        long elapsed = System.currentTimeMillis() - startts;
+        System.out.println("Running transform func took " + elapsed + " msec");
+
+        // compute geom field in the database, where it can happen in parallel
+        Statement setGeomFieldStmt = DbConnector.getStmtByDbName(Config.databaseName);
+        sql = "UPDATE " + bboxTableName + " SET geom=box( point(minx,miny), point(maxx,maxy) );";
+        System.out.println(sql);
+        long startTs = (new Date()).getTime();
+        setGeomFieldStmt.executeUpdate(sql);
+        setGeomFieldStmt.close();
+        long currTs = (new Date()).getTime();
+        System.out.println(
+                ((currTs - startTs) / 1000) + " secs for setting geom field in parallel");
+        startTs = currTs;
+
+        // create index - gist/spgist require logged table type
+        // TODO: consider sp-gist
+        Statement createIndexStmt = DbConnector.getStmtByDbName(Config.databaseName);
+        sql = "CREATE INDEX sp_" + bboxTableName + " ON " + bboxTableName + " USING gist (geom);";
+        System.out.println(sql);
+        createIndexStmt.executeUpdate(sql);
+        createIndexStmt.close();
+        currTs = (new Date()).getTime();
+        System.out.println(
+                ((currTs - startTs) / 1000)
+                        + " secs for CREATE INDEX sp_"
+                        + bboxTableName
+                        + " ON "
+                        + bboxTableName
+                        + " in parallel");
+
+        // cluster index
+        Statement bboxStmt = DbConnector.getStmtByDbName(Config.databaseName);
+        sql = "cluster " + bboxTableName + " using sp_" + bboxTableName + ";";
+        System.out.println(sql);
+        bboxStmt.executeUpdate(sql);
+    }
+}

--- a/back-end/src/main/java/index/PsqlNativeBoxIndexer.java
+++ b/back-end/src/main/java/index/PsqlNativeBoxIndexer.java
@@ -376,10 +376,10 @@ public class PsqlNativeBoxIndexer extends BoundingBoxIndexer {
                         + (isCitus ? " in parallel" : ""));
         startTs = currTs;
 
-        // don't use clustering
-        // sql = "cluster " + bboxTableName + " using sp_" + bboxTableName + ";";
-        // System.out.println(sql);
-        // bboxStmt.executeUpdate(sql);
+        Statement bboxStmt = DbConnector.getStmtByDbName(Config.databaseName);
+        sql = "cluster " + bboxTableName + " using sp_" + bboxTableName + ";";
+        System.out.println(sql);
+        bboxStmt.executeUpdate(sql);
     }
 
     @Override

--- a/back-end/src/main/java/index/PsqlNativeBoxIndexer.java
+++ b/back-end/src/main/java/index/PsqlNativeBoxIndexer.java
@@ -18,37 +18,15 @@ import project.Transform;
 public class PsqlNativeBoxIndexer extends BoundingBoxIndexer {
 
     private static PsqlNativeBoxIndexer instance = null;
-    private static boolean isCitus = false;
 
     // singleton pattern to ensure only one instance existed
     protected PsqlNativeBoxIndexer() {}
 
-    private PsqlNativeBoxIndexer(boolean isCitus) {
-        this.isCitus = isCitus;
-    }
-
     // thread-safe instance getter
-    public static synchronized PsqlNativeBoxIndexer getInstance(boolean isCitus) {
+    public static synchronized PsqlNativeBoxIndexer getInstance() {
 
-        if (instance == null) instance = new PsqlNativeBoxIndexer(isCitus);
+        if (instance == null) instance = new PsqlNativeBoxIndexer();
         return instance;
-    }
-
-    void run_citus_dml_ddl(Statement stmt, String sql) throws Exception {
-        System.out.println(sql + " -- also running on workers");
-        System.out.println(sql.replaceAll("\n", " "));
-        stmt.executeUpdate(sql);
-        sql = "select run_command_on_workers($CITUS$ " + sql + " $CITUS$);";
-        System.out.println(sql.replaceAll("\n", " "));
-        stmt.executeQuery(sql);
-    }
-
-    void run_citus_dml_ddl2(Statement stmt, String masterSql, String workerSql) throws Exception {
-        System.out.println(masterSql.replaceAll("\n", " "));
-        stmt.executeUpdate(masterSql);
-        String dworkerSql = "select run_command_on_workers($CITUS$ " + workerSql + " $CITUS$);";
-        System.out.println(dworkerSql.replaceAll("\n", " "));
-        stmt.executeQuery(dworkerSql);
     }
 
     @Override
@@ -56,16 +34,16 @@ public class PsqlNativeBoxIndexer extends BoundingBoxIndexer {
 
         Layer l = c.getLayers().get(layerId);
         Transform trans = l.getTransform();
+        Statement bboxStmt = DbConnector.getStmtByDbName(Config.databaseName);
 
         // step 0: create tables for storing bboxes and tiles
         String bboxTableName =
                 "bbox_" + Main.getProject().getName() + "_" + c.getId() + "layer" + layerId;
 
         // drop table if exists
-        Statement dropCreateStmt = DbConnector.getStmtByDbName(Config.databaseName);
         String sql = "drop table if exists " + bboxTableName + ";";
         System.out.println(sql);
-        dropCreateStmt.executeUpdate(sql);
+        bboxStmt.executeUpdate(sql);
 
         // create the bbox table
         // yes, citus supports unlogged tables!
@@ -73,146 +51,13 @@ public class PsqlNativeBoxIndexer extends BoundingBoxIndexer {
         sql = "CREATE UNLOGGED TABLE " + bboxTableName + " (";
         for (int i = 0; i < trans.getColumnNames().size(); i++)
             sql += trans.getColumnNames().get(i) + " text, ";
-        if (isCitus) {
-            sql += "citus_distribution_id int, ";
-        }
         sql +=
                 "cx double precision, cy double precision, minx double precision, miny double precision, maxx double precision, maxy double precision, geom box)";
         System.out.println(sql);
-        dropCreateStmt.executeUpdate(sql);
-        dropCreateStmt.close();
+        bboxStmt.executeUpdate(sql);
 
         // if this is an empty layer, return
         if (trans.getDb().equals("")) return;
-
-        // if this is an empty layer, return
-        if (trans.getDb().equals("src_db_same_as_kyrix")) {
-
-            // TODO: replace me.
-            System.out.println(
-                    "Transform database marked 'src_db_same_as_kyrix' - trying to pushdown...");
-            Statement pushdownIndexStmt = DbConnector.getStmtByDbName(Config.databaseName);
-
-            String transformFuncName = bboxTableName + "_transform_func";
-            String bboxFuncName = bboxTableName + "_bbox_func";
-            UnaryOperator<String> tsql =
-                    (sqlstr) -> {
-                        return (sqlstr.replaceAll("transfunc", transformFuncName)
-                                .replaceAll("bboxfunc", bboxFuncName)
-                                .replaceAll("bboxtbl", bboxTableName)
-                                .replaceAll("dbsource", trans.getDbsource()));
-                    };
-
-            // register transform JS function with Postgres/Citus
-            run_citus_dml_ddl(pushdownIndexStmt, tsql.apply("DROP FUNCTION IF EXISTS bboxfunc"));
-            run_citus_dml_ddl(pushdownIndexStmt, tsql.apply("DROP FUNCTION IF EXISTS transfunc"));
-
-            // bbox func
-            sql =
-                    tsql.apply(
-                            "CREATE OR REPLACE FUNCTION bboxfunc(v json) returns double precision[]"
-                                    + " AS $$ return [v.x, v.y, v.x-0.5, v.y-0.5, (+v.x)+0.5, (+v.y)+0.5]"
-                                    + "$$ LANGUAGE plv8");
-            // master needs 'stable' for citus to pushdown to workers
-            // workers need 'volatile' for pg11 to memoize and not call the function repeatedly per
-            // row
-            run_citus_dml_ddl2(
-                    pushdownIndexStmt, sql + " STABLE", sql); // append is safer than replace...
-
-            // transform func
-            sql =
-                    tsql.apply(
-                            "CREATE OR REPLACE FUNCTION transfunc(obj json, cw int, ch int, params json) returns json"
-                                    +
-                                    // TODO(security): SQL injection - perhaps use $foo<hard to
-                                    // guess number>$ ... $foo<#>$ ?
-                                    " AS $$ "
-                                    + trans.getTransformFuncBody()
-                                    + " $$ LANGUAGE plv8");
-            // master needs 'stable' for citus to pushdown to workers
-            // workers need 'volatile' for pg11 to memoize and not call the function repeatedly per
-            // row
-            run_citus_dml_ddl2(
-                    pushdownIndexStmt, sql + " STABLE", sql); // append is safer than replace...
-
-            // by distributing afterwards, loading is ~10x faster (minus a few minutes to distribute
-            // the data)
-            sql =
-                    tsql.apply(
-                            "SELECT create_distributed_table('bboxtbl', 'citus_distribution_id',"
-                                    + "colocate_with => 'dbsource')");
-            System.out.println(sql);
-            pushdownIndexStmt.executeQuery(sql);
-
-            // run transform func, create bboxtbl
-            sql =
-                    tsql.apply(
-                            "INSERT INTO bboxtbl(id,x,y,citus_distribution_id,cx,cy,minx,miny,maxx,maxy) "
-                                    + "SELECT id, x, y, citus_distribution_id, "
-                                    + "coords[1], coords[2], coords[3], coords[4], coords[5], coords[6] "
-                                    + "FROM ("
-                                    + "  SELECT (v->>'id') as id, (v->>'x') as x, (v->>'y') as y, "
-                                    + "         citus_distribution_id, "
-                                    + "         bboxfunc(v) coords"
-                                    + "  FROM ("
-                                    + "    SELECT transfunc(row_to_json(dbsource),"
-                                    + c.getW()
-                                    + ","
-                                    + c.getH()
-                                    + ",\'"
-                                    + Main.getProject()
-                                            .getRenderingParams()
-                                            .replaceAll("\'", "\'\'")
-                                    + "\'::json) v, citus_distribution_id FROM dbsource"
-                                    + "  ) sq1"
-                                    + ") sq2");
-            long startts = System.currentTimeMillis();
-            System.out.println("pipeline/insertion: " + sql);
-            pushdownIndexStmt.executeUpdate(sql);
-            long elapsed = System.currentTimeMillis() - startts;
-            System.out.println("Running transform func took " + elapsed + " msec");
-
-            // compute geom field in the database, where it can happen in parallel
-            Statement setGeomFieldStmt = DbConnector.getStmtByDbName(Config.databaseName);
-            sql =
-                    "UPDATE "
-                            + bboxTableName
-                            + " SET geom=box( point(minx,miny), point(maxx,maxy) );";
-            System.out.println(sql);
-            long startTs = (new Date()).getTime();
-            setGeomFieldStmt.executeUpdate(sql);
-            setGeomFieldStmt.close();
-            long currTs = (new Date()).getTime();
-            System.out.println(
-                    ((currTs - startTs) / 1000)
-                            + " secs for setting geom field"
-                            + (isCitus ? " in parallel" : ""));
-            startTs = currTs;
-
-            // create index - gist/spgist require logged table type
-            // TODO: consider sp-gist
-            Statement createIndexStmt = DbConnector.getStmtByDbName(Config.databaseName);
-            sql =
-                    "CREATE INDEX sp_"
-                            + bboxTableName
-                            + " ON "
-                            + bboxTableName
-                            + " USING gist (geom);";
-            System.out.println(sql);
-            createIndexStmt.executeUpdate(sql);
-            createIndexStmt.close();
-            currTs = (new Date()).getTime();
-            System.out.println(
-                    ((currTs - startTs) / 1000)
-                            + " secs for CREATE INDEX sp_"
-                            + bboxTableName
-                            + " ON "
-                            + bboxTableName
-                            + (isCitus ? " in parallel" : ""));
-            startTs = currTs;
-
-            return;
-        }
 
         // step 1: set up nashorn environment for running javascript code
         NashornScriptEngine engine = null;
@@ -229,10 +74,7 @@ public class PsqlNativeBoxIndexer extends BoundingBoxIndexer {
         int rowCount = 0;
         String insertSql = "INSERT INTO " + bboxTableName + " VALUES (";
         // for debugging, vary number of spaces after the commas
-        for (int i = 0; i < trans.getColumnNames().size(); i++) {
-            insertSql += "?,";
-        }
-        if (isCitus) insertSql += "?,";
+        for (int i = 0; i < trans.getColumnNames().size(); i++) insertSql += "?,";
         insertSql += "?,?,?,?,?,?)";
         System.out.println(insertSql);
         PreparedStatement preparedStmt =
@@ -275,7 +117,6 @@ public class PsqlNativeBoxIndexer extends BoundingBoxIndexer {
             int pscol = 1;
             for (int i = 0; i < numcols; i++)
                 preparedStmt.setString(pscol++, transformedRow.get(i).replaceAll("\'", "\'\'"));
-            if (isCitus) preparedStmt.setDouble(pscol++, rowCount);
             for (int i = 0; i < 6; i++) preparedStmt.setDouble(pscol++, curBbox.get(i));
             preparedStmt.addBatch();
             if (rowCount % batchsize == 0) {
@@ -314,57 +155,20 @@ public class PsqlNativeBoxIndexer extends BoundingBoxIndexer {
 
         startTs = (new Date()).getTime();
 
-        // TODO: move to parallel kyrix-indexing: pushdown this computation into the DB and run on
-        // each shard independently.
-        if (isCitus) {
-            Statement distributeStmt = DbConnector.getStmtByDbName(Config.databaseName);
-
-            // by distributing afterwards, loading is ~10x faster (minus a few minutes to distribute
-            // the data)
-            sql =
-                    "SELECT create_distributed_table('"
-                            + bboxTableName
-                            + "', 'citus_distribution_id');";
-            System.out.println(sql);
-            distributeStmt.executeQuery(sql);
-
-            // citus leaves leftover data on master when distributing non-empty tables - who knows
-            // why?
-            sql =
-                    "BEGIN; SET LOCAL citus.enable_ddl_propagation TO off; TRUNCATE "
-                            + bboxTableName
-                            + "; END;";
-            System.out.println(sql);
-            distributeStmt.executeUpdate(sql);
-            distributeStmt.close();
-
-            currTs = (new Date()).getTime();
-            System.out.println(
-                    ((currTs - startTs) / 1000) + " secs for create_distributed_table()");
-            startTs = currTs;
-        }
-
         // compute geom field in the database, where it can happen in parallel
-        Statement setGeomFieldStmt = DbConnector.getStmtByDbName(Config.databaseName);
         sql = "UPDATE " + bboxTableName + " SET geom=box( point(minx,miny), point(maxx,maxy) );";
         System.out.println(sql);
-        setGeomFieldStmt.executeUpdate(sql);
-        setGeomFieldStmt.close();
+        bboxStmt.executeUpdate(sql);
 
         currTs = (new Date()).getTime();
-        System.out.println(
-                ((currTs - startTs) / 1000)
-                        + " secs for setting geom field"
-                        + (isCitus ? " in parallel" : ""));
+        System.out.println(((currTs - startTs) / 1000) + " secs for setting geom field");
         startTs = currTs;
 
         // create index - gist/spgist require logged table type
         // TODO: consider sp-gist
-        Statement createIndexStmt = DbConnector.getStmtByDbName(Config.databaseName);
         sql = "CREATE INDEX sp_" + bboxTableName + " ON " + bboxTableName + " USING gist (geom);";
         System.out.println(sql);
-        createIndexStmt.executeUpdate(sql);
-        createIndexStmt.close();
+        bboxStmt.executeUpdate(sql);
 
         currTs = (new Date()).getTime();
         System.out.println(
@@ -372,11 +176,9 @@ public class PsqlNativeBoxIndexer extends BoundingBoxIndexer {
                         + " secs for CREATE INDEX sp_"
                         + bboxTableName
                         + " ON "
-                        + bboxTableName
-                        + (isCitus ? " in parallel" : ""));
-        startTs = currTs;
+                        + bboxTableName);
 
-        Statement bboxStmt = DbConnector.getStmtByDbName(Config.databaseName);
+        // cluster index
         sql = "cluster " + bboxTableName + " using sp_" + bboxTableName + ";";
         System.out.println(sql);
         bboxStmt.executeUpdate(sql);

--- a/back-end/src/main/java/index/SSVCitusIndexer.java
+++ b/back-end/src/main/java/index/SSVCitusIndexer.java
@@ -136,7 +136,7 @@ public class SSVCitusIndexer extends BoundingBoxIndexer {
         }
     }
 
-    private void setCommonVariables() throws SQLException, ClassNotFoundException {
+    private void setCommonVariables() throws Exception {
         System.out.println("Setting common variables...");
 
         // get current SSV object

--- a/back-end/src/main/java/index/SSVInMemoryIndexer.java
+++ b/back-end/src/main/java/index/SSVInMemoryIndexer.java
@@ -66,7 +66,7 @@ public class SSVInMemoryIndexer extends PsqlNativeBoxIndexer {
             return ret;
         }
 
-        public String getClusterAggString() {
+        public String getClusterAggString() throws Exception {
             JsonObject jsonObj = new JsonObject();
 
             // add numeric aggs
@@ -104,7 +104,12 @@ public class SSVInMemoryIndexer extends PsqlNativeBoxIndexer {
         public int compare(RTreeData o1, RTreeData o2) {
 
             String zCol = ssv.getzCol();
-            int zColId = ssv.getColumnNames().indexOf(zCol);
+            int zColId = 0;
+            try {
+                zColId = ssv.getColumnNames().indexOf(zCol);
+            } catch (Exception e) {
+                return 0; // this will probably cause an exception anyways
+            }
             String zOrder = ssv.getzOrder();
 
             float v1 = parseFloat(rawRows.get(o1.rowId).get(zColId));
@@ -165,7 +170,7 @@ public class SSVInMemoryIndexer extends PsqlNativeBoxIndexer {
         cleanUp();
     }
 
-    private void setCommonVariables() throws SQLException, ClassNotFoundException {
+    private void setCommonVariables() throws Exception {
         // get current SSV object
         ssv = Main.getProject().getSsvs().get(ssvIndex);
         numLevels = ssv.getNumLevels();
@@ -200,7 +205,7 @@ public class SSVInMemoryIndexer extends PsqlNativeBoxIndexer {
         Main.getProject().addBGRP(rpKey, "roughN", String.valueOf(rawRows.size()));
     }
 
-    private void computeClusterAggs() throws SQLException, ClassNotFoundException {
+    private void computeClusterAggs() throws Exception {
 
         // initialize R-tree0
         rtree0 = RTree.star().create();
@@ -315,7 +320,7 @@ public class SSVInMemoryIndexer extends PsqlNativeBoxIndexer {
         }
     }
 
-    private void writeToDB(int level) throws SQLException, ClassNotFoundException {
+    private void writeToDB(int level) throws Exception {
         // create tables
         bboxStmt = DbConnector.getStmtByDbName(Config.databaseName);
 
@@ -453,7 +458,7 @@ public class SSVInMemoryIndexer extends PsqlNativeBoxIndexer {
         return "";
     }
 
-    private void setInitialClusterAgg(RTreeData rd) {
+    private void setInitialClusterAgg(RTreeData rd) throws Exception {
         ArrayList<String> row = rawRows.get(rd.rowId);
 
         // convexHull
@@ -513,7 +518,7 @@ public class SSVInMemoryIndexer extends PsqlNativeBoxIndexer {
 
     // this function assumes that convexHull of child
     // is from one level lower than parent
-    private void mergeClusterAgg(RTreeData parent, RTreeData child) {
+    private void mergeClusterAgg(RTreeData parent, RTreeData child) throws Exception {
 
         // convexHull
         float[][] childConvexHull = new float[child.convexHull.length][2];

--- a/back-end/src/main/java/project/Layer.java
+++ b/back-end/src/main/java/project/Layer.java
@@ -2,6 +2,7 @@ package project;
 
 import index.Indexer;
 import java.io.Serializable;
+import java.sql.SQLException;
 import java.util.ArrayList;
 
 /** Created by wenbo on 4/3/18. */
@@ -62,7 +63,7 @@ public class Layer implements Serializable {
         return indexerType;
     }
 
-    public String getColStr(String tableName) {
+    public String getColStr(String tableName) throws SQLException, ClassNotFoundException {
 
         String colListStr = "";
         for (String col : transform.getColumnNames())

--- a/back-end/src/main/java/server/BoxRequestHandler.java
+++ b/back-end/src/main/java/server/BoxRequestHandler.java
@@ -80,6 +80,13 @@ public class BoxRequestHandler implements HttpHandler {
             Box oldBox = new Box(oMinX, oMinY, oMaxX, oMaxY);
             Boolean isJumping = Boolean.valueOf(queryMap.get("isJumping"));
 
+            // check predicates
+            if (!Server.checkPredicates(predicates, c)) {
+                Server.sendResponse(
+                        httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, "Bad predicates.");
+                return;
+            }
+
             // get box data
             long st = System.currentTimeMillis();
             data = boxGetter.getBox(c, v, minx, miny, oldBox, predicates);

--- a/back-end/src/main/java/server/CanvasRequestHandler.java
+++ b/back-end/src/main/java/server/CanvasRequestHandler.java
@@ -54,6 +54,13 @@ public class CanvasRequestHandler implements HttpHandler {
             for (int i = 0; i < c.getLayers().size(); i++)
                 predicates.add(queryMap.get("predicate" + i));
 
+            // check predicates
+            if (!Server.checkPredicates(predicates, c)) {
+                Server.sendResponse(
+                        httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, "Bad predicates.");
+                return;
+            }
+
             // calculate w or h if they are not pre-determined
             if (c.getwSql().length() > 0) {
                 String predicate = queryMap.get("predicate" + c.getwLayerId());

--- a/back-end/src/main/java/server/CanvasRequestHandler.java
+++ b/back-end/src/main/java/server/CanvasRequestHandler.java
@@ -101,7 +101,7 @@ public class CanvasRequestHandler implements HttpHandler {
     }
 
     private ArrayList<ArrayList<ArrayList<String>>> getStaticData(
-            Canvas c, ArrayList<String> predicates) throws SQLException, ClassNotFoundException {
+            Canvas c, ArrayList<String> predicates) throws Exception {
 
         // container for data
         ArrayList<ArrayList<ArrayList<String>>> data = new ArrayList<>();

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.net.ssl.HttpsURLConnection;
@@ -51,21 +52,26 @@ public class Server {
             e.printStackTrace();
             System.out.println("\n\n" + e.getMessage() + "\n");
 
-            // print out indexing error message
-            printIndexingErrorMessage();
-
             // clear project history and set current project to null
             ProjectRequestHandler.clearProjectHistory(Main.getProject().getName());
             Main.setProject(null);
 
-            // close db connections
-            DbConnector.closeAllConnections();
-            System.out.println("Server restarting....");
+            // print out indexing error message
+            printIndexingErrorMessage();
         }
         Server.startServer(Config.portNumber);
     }
 
     public static void printIndexingErrorMessage() {
+
+        // close db connections
+        try {
+            DbConnector.closeAllConnections();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        // print error message
         System.out.println(
                 "+---------------------------------------------------------+\n"
                         + "|ERROR!!! An exception occurred while indexing.           |\n"
@@ -80,10 +86,20 @@ public class Server {
                         + "|to contact Kyrix maintainers.                            |\n"
                         + "|                                                         |\n"
                         + "|Github: https://github.com/tracyhenry/kyrix              |\n"
-                        + "+---------------------------------------------------------+");
+                        + "+---------------------------------------------------------+\n"
+                        + "Server restarting....");
     }
 
     public static void printServingErrorMessage() {
+
+        // close db connections
+        try {
+            DbConnector.closeAllConnections();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        // print error message
         System.out.println(
                 "+-------------------------------------------------------------+\n"
                         + "|ERROR!!! An exception occurred while serving an HTTP request.|\n"
@@ -96,7 +112,8 @@ public class Server {
                         + "|indexes, or reach out to the kyrix maintainers for help.     |\n"
                         + "|                                                             |\n"
                         + "|Github: https://github.com/tracyhenry/kyrix                  |\n"
-                        + "+-------------------------------------------------------------+");
+                        + "+-------------------------------------------------------------+\n"
+                        + "Server restarting...");
     }
 
     public static void terminate() {

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -8,12 +8,14 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import javax.net.ssl.HttpsURLConnection;
 import main.Config;
 import main.DbConnector;
 import main.Main;
+import project.Canvas;
 
 /** Created by wenbo on 1/8/18. */
 public class Server {
@@ -114,6 +116,77 @@ public class Server {
                         + "|Github: https://github.com/tracyhenry/kyrix                  |\n"
                         + "+-------------------------------------------------------------+\n"
                         + "Server restarting...");
+    }
+
+    public static boolean checkPredicates(ArrayList<String> predicates, Canvas c) {
+        boolean allValid = true;
+        for (int i = 0; i < predicates.size(); i++) {
+            String predicate = predicates.get(i);
+            if (predicate.isEmpty()) continue;
+            ArrayList<String> colNames = c.getLayers().get(i).getTransform().getColumnNames();
+            if (!checkPredicate(predicate, colNames)) {
+                System.out.println(predicate);
+                System.out.println(colNames);
+                allValid = false;
+                break;
+            }
+        }
+        return allValid;
+    }
+
+    private static boolean checkPredicate(String predicate, ArrayList<String> colNames) {
+
+        int len = predicate.length();
+
+        // length must be >= 2
+        // the boundary of the recursion should be colName='XXX'
+        if (len < 2) return false;
+        if (predicate.charAt(0) != '(' || predicate.charAt(len - 1) != ')') return false;
+
+        // find AND or OR
+        int sumParenthesis = 0;
+        int pos = -1;
+        String operator = "";
+        for (int i = 1; i < len - 1; i++) {
+            if (predicate.charAt(i) == '(') sumParenthesis++;
+            if (predicate.charAt(i) == ')') sumParenthesis--;
+            if (sumParenthesis == 0) {
+                if (i + 5 < len && predicate.substring(i, i + 5).equals(" AND ")) {
+                    pos = i;
+                    operator = "AND";
+                } else if (i + 4 < len && predicate.substring(i, i + 4).equals(" OR ")) {
+                    pos = i;
+                    operator = "OR";
+                } else if (predicate.charAt(i) == '=') {
+                    pos = i;
+                    operator = "=";
+                }
+            }
+        }
+        if (pos == -1) return false;
+        if (operator == "AND") {
+            String l = predicate.substring(1, pos);
+            String r = predicate.substring(pos + 5, len - 1);
+            return checkPredicate(l, colNames) && checkPredicate(r, colNames);
+        } else if (operator == "OR") {
+            String l = predicate.substring(1, pos);
+            String r = predicate.substring(pos + 4, len - 1);
+            return checkPredicate(l, colNames) && checkPredicate(r, colNames);
+        } else if (operator == "=") {
+            String l = predicate.substring(1, pos);
+            String r = predicate.substring(pos + 1, len - 1);
+            // l must be a column
+            boolean isAColumn = false;
+            for (String colName : colNames)
+                if (colName.toLowerCase().equals(l.toLowerCase())) isAColumn = true;
+            if (!isAColumn) return false;
+            // r must begin and end with a single quote
+            if (r.length() < 2) return false;
+            if (r.charAt(0) != '\'' || r.charAt(r.length() - 1) != '\'') return false;
+            return true;
+        }
+
+        return false;
     }
 
     public static void terminate() {

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -118,7 +118,8 @@ public class Server {
                         + "Server restarting...");
     }
 
-    public static boolean checkPredicates(ArrayList<String> predicates, Canvas c) {
+    public static boolean checkPredicates(ArrayList<String> predicates, Canvas c)
+            throws SQLException, ClassNotFoundException {
         boolean allValid = true;
         for (int i = 0; i < predicates.size(); i++) {
             String predicate = predicates.get(i);

--- a/back-end/src/main/java/server/TileRequestHandler.java
+++ b/back-end/src/main/java/server/TileRequestHandler.java
@@ -67,9 +67,17 @@ public class TileRequestHandler implements HttpHandler {
             for (int i = 0; i < c.getLayers().size(); i++)
                 predicates.add(queryMap.get("predicate" + i));
             Boolean isJumping = Boolean.valueOf(queryMap.get("isJumping"));
+
+            // check predicates
+            if (!Server.checkPredicates(predicates, c)) {
+                Server.sendResponse(
+                        httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, "Bad predicates.");
+                return;
+            }
+
+            // fetch data
             long st = System.currentTimeMillis();
             data = TileCache.getTile(c, minx, miny, predicates);
-
             double fetchTime = System.currentTimeMillis() - st;
             int intersectingRows = 0;
             for (int i = 0; i < data.size(); i++) {

--- a/back-end/src/main/java/server/ViewportRequestHandler.java
+++ b/back-end/src/main/java/server/ViewportRequestHandler.java
@@ -65,8 +65,16 @@ public class ViewportRequestHandler implements HttpHandler {
             Canvas c = Main.getProject().getCanvas(canvasId);
             for (int i = 0; i < c.getLayers().size(); i++)
                 predicates.add(queryMap.get("predicate" + i));
-            data = getData(canvasId, predicates);
 
+            // check predicates
+            if (!Server.checkPredicates(predicates, c)) {
+                Server.sendResponse(
+                        httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, "Bad predicates.");
+                return;
+            }
+
+            // fetch data
+            data = getData(canvasId, predicates);
             if (data == null) {
                 Server.sendResponse(
                         httpExchange, HttpsURLConnection.HTTP_BAD_REQUEST, "Bad predicates.");

--- a/compiler/src/template-api/SSV.js
+++ b/compiler/src/template-api/SSV.js
@@ -187,7 +187,9 @@ function SSV(args) {
         args.marks.cluster.aggregate.measures.length > 1
     )
         throw new Error(
-            "Constructing SSV: more than one measure column specified for circle mode."
+            "Constructing SSV: more than one measure column specified for " +
+                args.marks.cluster.mode +
+                " mode."
         );
     for (var i = 0; i < args.marks.cluster.aggregate.dimensions.length; i++) {
         if (!("field" in args.marks.cluster.aggregate.dimensions[i]))
@@ -792,6 +794,9 @@ function getLayerRenderer() {
     function renderHeatmapBody() {
         var rpKey = "ssv_" + args.ssvId.substring(0, args.ssvId.indexOf("_"));
         var params = args.renderingParams[rpKey];
+        var agg;
+        var curMeasure = params.aggMeasures[0];
+        agg = curMeasure.function + "(" + curMeasure.field + ")";
         var radius = params.heatmapRadius;
         var heatmapWidth, heatmapHeight, x, y;
         if ("tileX" in args) {
@@ -811,7 +816,7 @@ function getLayerRenderer() {
         var translatedData = data.map(d => ({
             x: d.cx - (x - radius),
             y: d.cy - (y - radius),
-            w: +JSON.parse(d.clusterAgg)["count(*)"]
+            w: +JSON.parse(d.clusterAgg)[agg]
         }));
 
         // render heatmap
@@ -844,8 +849,8 @@ function getLayerRenderer() {
         var alphaCanvas = document.createElement("canvas");
         alphaCanvas.width = heatmapWidth;
         alphaCanvas.height = heatmapHeight;
-        var minWeight = params[args.ssvId + "_count(*)_min"]; // set in the BGRP (back-end generated rendering params)
-        var maxWeight = params[args.ssvId + "_count(*)_max"]; // set in the BGRP
+        var minWeight = params[args.ssvId + "_" + agg + "_min"]; // set in the BGRP (back-end generated rendering params)
+        var maxWeight = params[args.ssvId + "_" + agg + "_max"]; // set in the BGRP
         var alphaCtx = alphaCanvas.getContext("2d");
         var tpl = _getPointTemplate(radius);
         for (var i = 0; i < translatedData.length; i++) {

--- a/docker-scripts/load-csv.sh
+++ b/docker-scripts/load-csv.sh
@@ -1,8 +1,27 @@
 #!/bin/bash
 
-# check input csv file exists
+usage="load-csv.sh: a script to load a CSV file into Kyrix's PostgreSQL container. Usage:
+
+    ./docker-scripts/load-csv.sh CSV_FILE [OPTIONS]  (must be run under root Kyrix folder)
+
+where OPTIONS include:
+    --dbname DBNAME: name of the database that you want to load the CSV file into.
+    --tablename: name of the table that you want to load the CSV file into.
+    --delimiter: the delimiter used in the CVS file, e.g. \"\\t\"
+
+Both --dbname and --tablename default to the name of the CSV file (without the .csv suffix).
+If the database/table does not exist, it will be created. "
+
 CSV_FILE="$1"
 shift
+
+# output usage
+if [ "x$CSV_FILE" = "x-h" ] || [ "x$CSV_FILE" = "x--help" ]; then
+    echo "$usage"
+    exit
+fi
+
+# check input csv file exists
 if [ ! -f $CSV_FILE ]; then
     echo "Input file $CSV_FILE Not found"
     exit

--- a/docker-scripts/load-sql.sh
+++ b/docker-scripts/load-sql.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
 
-# check input sql file exists
+usage="load-sql.sh: a script to load a SQL dump file into Kyrix's PostgreSQL container. Usage:
+
+    ./docker-scripts/load-sql.sh SQL_DUMP_FILE [OPTIONS]  (must be run under root Kyrix folder)
+
+where OPTIONS include:
+    --dbname DBNAME: name of the database that you want to load the SQL dump file into.
+
+--dbname defaults to the name of the SQL dump file (without the .sql suffix).
+If the database does not exist, it will be created. "
+
 SQL_FILE="$1"
 shift
+
+# output usage
+if [ "x$SQL_FILE" = "x-h" ] || [ "x$SQL_FILE" = "x--help" ]; then
+    echo "$usage"
+    exit
+fi
+
+# check input sql file exists
 if [ ! -f $SQL_FILE ]; then
     echo "Input file $SQL_FILE Not found"
     exit

--- a/front-end/js/dynamicLayers.js
+++ b/front-end/js/dynamicLayers.js
@@ -262,17 +262,15 @@ function renderTiles(viewId, viewportX, viewportY, vpW, vpH, optionalArgs) {
                     if (tileSvg.empty()) break;
 
                     // draw current layer
-                    var optionalArgsWithTileXY = Object.assign(
-                        {},
-                        optionalArgs
-                    );
-                    optionalArgsWithTileXY["tileX"] = x;
-                    optionalArgsWithTileXY["tileY"] = y;
-                    optionalArgsWithTileXY["ssvId"] = curLayer.ssvId;
+                    var optionalArgsMore = Object.assign({}, optionalArgs);
+                    optionalArgsMore["tileX"] = x;
+                    optionalArgsMore["tileY"] = y;
+                    optionalArgsMore["layerId"] = i;
+                    optionalArgsMore["ssvId"] = curLayer.ssvId;
                     curLayer.rendering.parseFunction()(
                         tileSvg,
                         renderData[i],
-                        optionalArgsWithTileXY
+                        optionalArgsMore
                     );
                     tileSvg.style("opacity", 1.0);
 
@@ -478,19 +476,17 @@ function renderDynamicBoxes(
                     gvd.renderData[i] = newLayerData;
 
                     // draw current layer
-                    var optionalArgsWithBoxWHXY = Object.assign(
-                        {},
-                        optionalArgs
-                    );
-                    optionalArgsWithBoxWHXY["boxX"] = x;
-                    optionalArgsWithBoxWHXY["boxY"] = y;
-                    optionalArgsWithBoxWHXY["boxW"] = response.boxW;
-                    optionalArgsWithBoxWHXY["boxH"] = response.boxH;
-                    optionalArgsWithBoxWHXY["ssvId"] = curLayer.ssvId;
+                    var optionalArgsMore = Object.assign({}, optionalArgs);
+                    optionalArgsMore["boxX"] = x;
+                    optionalArgsMore["boxY"] = y;
+                    optionalArgsMore["boxW"] = response.boxW;
+                    optionalArgsMore["boxH"] = response.boxH;
+                    optionalArgsMore["layerId"] = i;
+                    optionalArgsMore["ssvId"] = curLayer.ssvId;
                     curLayer.rendering.parseFunction()(
                         dboxSvg,
                         renderData[i],
-                        optionalArgsWithBoxWHXY
+                        optionalArgsMore
                     );
 
                     // tooltip

--- a/front-end/js/embed/API.js
+++ b/front-end/js/embed/API.js
@@ -179,6 +179,8 @@ export function reRender(viewId, layerId, additionalArgs) {
     var oldArgs = getOptionalArgs(viewId);
     oldArgs["viewportX"] = curVp["vpX"];
     oldArgs["viewportY"] = curVp["vpY"];
+    oldArgs["layerId"] = layerId;
+    oldArgs["ssvId"] = gvd.curCanvas.layers[layerId].ssvId;
     var allArgs = Object.assign({}, oldArgs, additionalArgs);
 
     // re render the svg

--- a/front-end/js/embed/example_nba.html
+++ b/front-end/js/embed/example_nba.html
@@ -22,11 +22,17 @@
             href="https://fonts.googleapis.com/css?family=Source Serif Pro"
             rel="stylesheet"
         />
+        <link
+            href="https://fonts.googleapis.com/css?family=Open+Sans"
+            rel="stylesheet"
+        />
         <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/gpu.js@2.0.0-rc.19/dist/gpu-browser.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.17.0/dist/jquery.validate.min.js"></script>
         <script src="https://d3js.org/d3.v5.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-element-queries@1.2.1/src/ElementQueries.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-element-queries@1.2.1/src/ResizeSensor.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-legend/2.25.6/d3-legend.min.js"></script>
         <script src="kyrix.js"></script>
         <script>
             // TODO: change the address where the kyrix backend is running, has to start with http://
@@ -36,7 +42,7 @@
             kyrix.initializeApp(serverAddr);
 
             // logs to console every time a jump is finished
-            kyrix.on("jump", "nba", function() {
+            kyrix.on("jumpstart", "nba", function() {
                 console.log("Jump to " + kyrix.getCurrentCanvasId("nba"));
             });
 

--- a/front-end/js/embed/example_usmap.html
+++ b/front-end/js/embed/example_usmap.html
@@ -18,11 +18,17 @@
             href="https://fonts.googleapis.com/css?family=Source Serif Pro"
             rel="stylesheet"
         />
+        <link
+            href="https://fonts.googleapis.com/css?family=Open+Sans"
+            rel="stylesheet"
+        />
         <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/gpu.js@2.0.0-rc.19/dist/gpu-browser.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.17.0/dist/jquery.validate.min.js"></script>
         <script src="https://d3js.org/d3.v5.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-element-queries@1.2.1/src/ElementQueries.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-element-queries@1.2.1/src/ResizeSensor.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-legend/2.25.6/d3-legend.min.js"></script>
         <script src="kyrix.js"></script>
         <script>
             // TODO: change the address where the kyrix backend is running, has to start with http://

--- a/front-end/js/globalVar.js
+++ b/front-end/js/globalVar.js
@@ -36,6 +36,7 @@ function getOptionalArgs(viewId) {
     for (var i = 0; i < gvd.predicates.length; i++)
         predicateDict["layer" + i] = gvd.predicates[i];
     var optionalArgs = {
+        canvasId: gvd.curCanvas.id,
         canvasW: gvd.curCanvas.w,
         canvasH: gvd.curCanvas.h,
         pyramidLevel: gvd.curCanvas.pyramidLevel,

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -453,9 +453,16 @@ function registerJumps(viewId, svg, layerId) {
                 .select(viewClass + "#jumppopover")
                 .node()
                 .getBoundingClientRect().height;
+            var kyrixDivBox = d3
+                .select(".kyrixdiv")
+                .node()
+                .getBoundingClientRect();
             d3.select(viewClass + "#jumppopover")
-                .style("left", d3.event.pageX + "px")
-                .style("top", d3.event.pageY - popoverHeight / 2 + "px");
+                .style("left", d3.event.pageX - kyrixDivBox.left + "px")
+                .style(
+                    "top",
+                    d3.event.pageY - kyrixDivBox.top - popoverHeight / 2 + "px"
+                );
         });
     });
 }

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -326,7 +326,7 @@ function startJump(viewId, d, jump, optionalArgs) {
     )
         semanticJump(viewId, jump, predArray, newVpX, newVpY, d);
     else if (jump.type == param.load)
-        load(predArray, newVpX, newVpY, 1, jump.destViewId, jump.destId);
+        load(predArray, newVpX, newVpY, 1, jump.destViewId, jump.destId, jump);
     else if (jump.type == param.highlight) highlight(predArray, jump);
 }
 

--- a/front-end/js/jumpAnimation.js
+++ b/front-end/js/jumpAnimation.js
@@ -35,11 +35,34 @@ function animateSemanticZoom(viewId, jump, newVpX, newVpY, tuple) {
                 return d == tuple;
             })
             .each(function() {
-                var bbox = this.getBBox();
-                minx = Math.min(minx, bbox.x);
-                miny = Math.min(miny, bbox.y);
-                maxx = Math.max(maxx, bbox.x + bbox.width);
-                maxy = Math.max(maxy, bbox.y + bbox.height);
+                // find the parent main g
+                var ancestor = this.parentElement;
+                while (!ancestor.classList.contains("maing"))
+                    ancestor = ancestor.parentElement;
+
+                // get client dx & dy
+                var thisBox = this.getBoundingClientRect();
+                var ancestorBox = ancestor.getBoundingClientRect();
+                var dx = thisBox.x - ancestorBox.x;
+                var dy = thisBox.y - ancestorBox.y;
+
+                // because here we use client coordinates to infer svg coordinates,
+                // we need to multiply a scale factor
+                // which is how much the svg viewport has been scaled,
+                // which equals to curViewport[2] / containerW (see comments in zoomButton.js)
+                var containerW = d3.select("#containerSvg").attr("width");
+                var curViewport = d3.select("#containerSvg").attr("viewBox");
+                var curViewportW =
+                    curViewport == null
+                        ? containerW
+                        : curViewport.split(" ")[2];
+                var m = curViewportW / containerW;
+
+                // now get minx, miny, maxx, maxy
+                minx = Math.min(minx, dx * m);
+                miny = Math.min(miny, dy * m);
+                maxx = Math.max(maxx, (dx + thisBox.width) * m);
+                maxy = Math.max(maxy, (dy + thisBox.height) * m);
             });
     } else {
         minx = +tuple.cx - tupleWidth / 2.0;

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -328,9 +328,6 @@ function pageOnLoad(serverAddr) {
 
                 // initialize zoom buttons, must before getCurCanvas is called
                 drawZoomButtons(viewId);
-                d3.select(window).on("resize.zoombutton", function() {
-                    for (var viewId in globalVar.views) drawZoomButtons(viewId);
-                });
 
                 // render this view
                 if (gvd.curCanvasId != "") {
@@ -357,6 +354,7 @@ function pageOnLoad(serverAddr) {
     // add resize event listener to kyrixdiv
     new ResizeSensor(kyrixDiv.node(), function() {
         resizeKyrixSvg();
+        for (var viewId in globalVar.views) drawZoomButtons(viewId);
     });
 
     // return div node instead of selection

--- a/front-end/js/staticLayers.js
+++ b/front-end/js/staticLayers.js
@@ -21,6 +21,7 @@ function renderStaticLayers(viewId) {
         var renderFunc = curLayer.rendering.parseFunction();
         var curSvg = d3.select(viewClass + ".layerg.layer" + i).select("svg");
         var args = getOptionalArgs(viewId);
+        args["layerId"] = i;
         args["ssvId"] = curLayer.ssvId;
         renderFunc(curSvg, gvd.curStaticData[i], args);
 

--- a/front-end/js/zoomButton.js
+++ b/front-end/js/zoomButton.js
@@ -33,18 +33,39 @@ function drawZoomButtons(viewId) {
             .html('<span class="glyphicon glyphicon-zoom-out"></span>');
 
     // position the buttons at fixed positions in the top-left of the kyrixdiv
-    var leftMargin = 20;
-    var topMargin = 20;
+    var bbox = d3
+        .select("#containerSvg")
+        .node()
+        .getBoundingClientRect();
+
+    // in pageOnLoad.js, we have curViewport[2] = (containerW * containerW) / realW
+    // realW / containerW = (containerW * containerW) / curViewport[2] / containerW
+    //                    = containerW / curViewport[2]
+    var containerW = d3.select("#containerSvg").attr("width");
+    var curViewport = d3.select("#containerSvg").attr("viewBox");
+    var curViewportW;
+    if (curViewport == null) curViewportW = containerW;
+    else curViewportW = curViewport.split(" ")[2];
+    var bLeft =
+        +bbox.left +
+        (+d3.select(viewClass + ".viewsvg").attr("x") * containerW) /
+            curViewportW;
+    var bTop =
+        +bbox.top +
+        (+(+d3.select(viewClass + ".viewsvg").attr("y")) * containerW) /
+            curViewportW;
+    var leftMargin = 50;
+    var topMargin = 80;
     var dist = 50;
     d3.select(viewClass + ".gobackbutton")
-        .style("top", topMargin + "px")
-        .style("left", leftMargin + "px");
+        .style("top", bTop + topMargin + "px")
+        .style("left", bLeft - leftMargin + "px");
     d3.select(viewClass + ".zoominbutton")
-        .style("top", topMargin + dist + "px")
-        .style("left", leftMargin + "px");
+        .style("top", bTop + topMargin + dist + "px")
+        .style("left", bLeft - leftMargin + "px");
     d3.select(viewClass + ".zoomoutbutton")
-        .style("top", topMargin + dist * 2 + "px")
-        .style("left", leftMargin + "px");
+        .style("top", bTop + topMargin + dist * 2 + "px")
+        .style("left", bLeft - leftMargin + "px");
 }
 
 // called after a new canvas is completely rendered

--- a/run-kyrix.sh
+++ b/run-kyrix.sh
@@ -1,21 +1,16 @@
 #!/bin/bash
 
-# usage:
-# --nba: Run the NBA example upon start. You would need to wait the indexing for about a minute.
-# --dbport PORT_NUMBER: Specify the host port number of the postgres container.
-# --kyrixport PORT_NUMBER: Specify the host port number of the kyrix backend container.
-# --postgis: Start the DB container with postgis. You need to either start from scratch or run with --build to let docker rebuild the images.
-# --build: Rebuild the docker images before starting.
-# --mavenopts: Pass in custom Maven configuration.
-# --stop: Stop the containers.
-# --down: Remove containers, the network and volumes.
-
-echo -e "\nStopping existing containers..."
-docker-compose stop
-echo -e "Done.\n"
-
-start_time=$(date +%s)
-#echo "Current UNIX timestamp: $start_time"
+usage="
+run-kyrix.sh: a script to start Kyrix docker containers. Usage:
+    --help: show usage.
+    --nba: run the NBA example upon start. You would need to wait the indexing for about a minute.
+    --dbport PORT_NUMBER: specify the host port number of the postgres container. Default 5432.
+    --kyrixport PORT_NUMBER: specify the host port number of the kyrix backend container. Default 8000.
+    --postgis: start the DB container with postgis. You need to either start from scratch or run with --build to let docker rebuild the images.
+    --build: rebuild the docker images before starting.
+    --mavenopts: pass in custom Maven configuration. Default sets memory to 512MB.
+    --stop: stop the containers.
+    --down: remove containers, the network and volumes."
 
 DB_PORT=5432
 KYRIX_PORT=8000
@@ -30,6 +25,10 @@ while [[ $# -gt 0 ]]
 do
     key="$1"
     case $key in
+        -h|--help)
+            echo "$usage"
+            exit
+            ;;
         --nba)
             START_APP=1
             shift
@@ -71,6 +70,13 @@ do
             ;;
     esac
 done
+
+echo -e "\nStopping existing containers..."
+docker-compose stop
+echo -e "Done.\n"
+
+start_time=$(date +%s)
+#echo "Current UNIX timestamp: $start_time"
 
 # stop
 if [ "x$STOP" = "x1" ]; then

--- a/run-kyrix.sh
+++ b/run-kyrix.sh
@@ -7,6 +7,8 @@
 # --postgis: Start the DB container with postgis. You need to either start from scratch or run with --build to let docker rebuild the images.
 # --build: Rebuild the docker images before starting.
 # --mavenopts: Pass in custom Maven configuration.
+# --stop: Stop the containers.
+# --down: Remove containers, the network and volumes.
 
 echo -e "\nStopping existing containers..."
 docker-compose stop
@@ -21,6 +23,8 @@ START_APP=0
 BUILD_STAGE="pg-plv8"
 REBUILD=""
 KYRIX_MAVEN_OPTS="-Xmx512m"
+STOP=0
+DOWN=0
 
 while [[ $# -gt 0 ]]
 do
@@ -53,6 +57,14 @@ do
             shift
             shift
             ;;
+        --stop)
+            STOP=1
+            shift
+            ;;
+        --down)
+            DOWN=1
+            shift
+            ;;
         *)
             echo "Wrong argument name $key"
             exit
@@ -60,15 +72,39 @@ do
     esac
 done
 
+# stop
+if [ "x$STOP" = "x1" ]; then
+    exit
+fi
+
+# down
+if [ "x$DOWN" = "x1" ]; then
+    echo -e "\nRemoving containers and networks..."
+    docker-compose down -v
+    echo -e "Done.\n"
+    exit
+fi
+
 START_APP=$START_APP DB_PORT=$DB_PORT KYRIX_PORT=$KYRIX_PORT BUILD_STAGE=$BUILD_STAGE KYRIX_MAVEN_OPTS=$KYRIX_MAVEN_OPTS docker-compose up $REBUILD -d
 
 source docker-scripts/spinner.sh
+pg_start_time=$(date +%s)
 # waiting for kyrix_db_1 to start
 while [ 1 ]; do
     if docker logs 2>&1 --since $start_time kyrix_db_1 | grep -q "LOG:  database system is ready to accept connections"; then
         break;
     fi;
     spin "waiting for the Postgres container to start (be patient, it might take a few minutes)..."
+    cur_time=$(date +%s)
+    if [ $((cur_time - pg_start_time)) -gt 180 ]; then
+        echo -e "\nPostgres has taken more than 3 minutes to start, which is not normal."
+        echo "Try run 'sudo docker logs kyrix_db_1' in a separate terminal tab to inspect docker logs."
+        echo "If the log looks like there is an error, you should clean up docker (sudo ./run-kyrix.sh --down) and then restart."
+        echo "Note that './run-kyrix --down' will clear the database. If you want to backup the database before restarting,"
+        echo -e "please contact Kyrix maintainers on Github (https://github.com/tracyhenry/kyrix).\n"
+        echo "exiting..."
+        exit
+    fi
 done
 
 # Tune postgres
@@ -82,11 +118,22 @@ echo -e "Done.\n"
 
 # waiting for kyrix back-end to start
 spin_msg_printed=0
+backend_start_time=$(date +%s)
 while [ 1 ]; do
     if docker logs 2>&1 --since $start_time kyrix_kyrix_1 | grep -q "Backend server started"; then
         break;
     fi;
     spin "waiting for Kyrix backend to start..."
+    cur_time=$(date +%s)
+    if [ $((cur_time - backend_start_time)) -gt 180 ]; then
+        echo -e "\nKyrix backend has taken more than 3 minutes to start, which is not normal."
+        echo "Try run 'sudo docker logs kyrix_kyrix_1' in a separate terminal tab to inspect docker logs."
+        echo "If the log looks like there is an error, you should clean up docker (sudo ./run-kyrix.sh --down) and then restart."
+        echo "Note that './run-kyrix --down' will clear the database. If you want to backup the database before restarting,"
+        echo -e "please contact Kyrix maintainers on Github (https://github.com/tracyhenry/kyrix).\n"
+        echo "exiting..."
+        exit
+    fi
 done
 
 # redirect to docker logs

--- a/run-kyrix.sh
+++ b/run-kyrix.sh
@@ -72,7 +72,7 @@ do
 done
 
 echo -e "\nStopping existing containers..."
-docker-compose stop
+docker-compose -p kyrix stop
 echo -e "Done.\n"
 
 start_time=$(date +%s)
@@ -86,12 +86,12 @@ fi
 # down
 if [ "x$DOWN" = "x1" ]; then
     echo -e "\nRemoving containers and networks..."
-    docker-compose down -v
+    docker-compose -p kyrix down -v
     echo -e "Done.\n"
     exit
 fi
 
-START_APP=$START_APP DB_PORT=$DB_PORT KYRIX_PORT=$KYRIX_PORT BUILD_STAGE=$BUILD_STAGE KYRIX_MAVEN_OPTS=$KYRIX_MAVEN_OPTS docker-compose up $REBUILD -d
+START_APP=$START_APP DB_PORT=$DB_PORT KYRIX_PORT=$KYRIX_PORT BUILD_STAGE=$BUILD_STAGE KYRIX_MAVEN_OPTS=$KYRIX_MAVEN_OPTS docker-compose -p kyrix up $REBUILD -d
 
 source docker-scripts/spinner.sh
 pg_start_time=$(date +%s)


### PR DESCRIPTION
finished a laundry list of things required/complained by people over past 18 months

- fixed #121 
- fixed #120 
- fixed #97 
- fixed #60 using a predicate validator
- added `canvasId` and `layerId` to `optionalArgs` when possible
- upon serving errors, close all pg connections so the next query can be run
- separated citus and native box code
- removed try/catch in `getColumnNames()` so errors can be caught higher up
- made the web embedding examples work with the updated APIs
- added `down` and `stop` option for `run-kyrix.sh`
- fixed #129 with a 3-minute timeout
- added `-h`  `--help` options to docker scripts (`load-csv` `load-sql` `run-kyrix`)
- provided project name to docker-compose commands, so the root directory name won't alter container names
- updated docker installation instructions (docker-compose requires `v1.17.0`+)
- arbitrary aggregation for heatmap SSVs