### PR TITLE
geographic axes for Kyrix-S

### DIFF
--- a/back-end/src/main/java/index/SSVInMemoryIndexer.java
+++ b/back-end/src/main/java/index/SSVInMemoryIndexer.java
@@ -221,6 +221,9 @@ public class SSVInMemoryIndexer extends PsqlNativeBoxIndexer {
         rawDbStmt.executeUpdate(sql);
 
         sql = "DROP FUNCTION get_coord";
+        System.out.println(sql);
+        rawDbStmt.executeUpdate(sql);
+
         sql =
                 "CREATE OR REPLACE FUNCTION get_coord(lat float, lon float) returns jsonb as $$"
                         + ssv.getGetCoordinatesFromLatLonBody()

--- a/back-end/src/main/java/project/SSV.java
+++ b/back-end/src/main/java/project/SSV.java
@@ -22,9 +22,14 @@ public class SSV {
     private int xColId = -1, yColId = -1, zColId = -1;
     private double loX = Double.NaN, loY, hiX, hiY;
     private String mergeClusterAggs,
+            getCoordinatesFromLatLonBody,
             getCitusSpatialHashKeyBody,
             singleNodeClusteringBody,
             mergeClustersAlongSplitsBody;
+    private double geoLat, geoLon;
+    private String geoLatCol, geoLonCol;
+    private int geoInitialLevel;
+    private boolean mapBackground;
 
     public String getQuery() {
         return query;
@@ -182,8 +187,36 @@ public class SSV {
         return hiY;
     }
 
+    public double getGeoLat() {
+        return geoLat;
+    }
+
+    public double getGeoLon() {
+        return geoLon;
+    }
+
+    public String getGeoLatCol() {
+        return geoLatCol;
+    }
+
+    public String getGeoLonCol() {
+        return geoLonCol;
+    }
+
+    public int getGeoInitialLevel() {
+        return geoInitialLevel;
+    }
+
+    public boolean isMapBackground() {
+        return mapBackground;
+    }
+
     public String getMergeClusterAggs() {
         return mergeClusterAggs;
+    }
+
+    public String getGetCoordinatesFromLatLonBody() {
+        return getCoordinatesFromLatLonBody;
     }
 
     public String getGetCitusSpatialHashKeyBody() {

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -279,7 +279,10 @@ function addSSV(ssv, args) {
         bboxW: ssv.bboxW,
         bboxH: ssv.bboxH,
         zoomFactor: ssv.zoomFactor,
-        fadeInDuration: 200
+        fadeInDuration: 200,
+        geoInitialLevel: ssv.geoInitialLevel,
+        geoInitialCenterLat: ssv.geoLat,
+        geoInitialCenterLon: ssv.geoLon
     };
     renderingParams = {
         ...renderingParams,
@@ -357,6 +360,24 @@ function addSSV(ssv, args) {
 
         // tooltips
         curLayer.addTooltip(ssv.tooltipColumns, ssv.tooltipAliases);
+
+        // map layer
+        if (ssv.mapBackground) {
+            var mapLayer = new Layer(
+                require("./Transform").defaultEmptyTransform,
+                false
+            );
+            curCanvas.addLayer(mapLayer);
+            mapLayer.addRenderingFunc(ssv.getMapRenderer());
+            mapLayer.addPlacement({
+                centroid_x: "con:0",
+                centroid_y: "con:0",
+                width: "con:0",
+                height: "con:0"
+            });
+            mapLayer.setFetchingScheme("dbox", false);
+            mapLayer.setSSVId(this.ssvs.length - 1 + "_" + i);
+        }
 
         // axes
         if (ssv.axis) {


### PR DESCRIPTION
This PR allows specification of geo axes, freeing the user from manually transforming lat/lon to screen coordinates. 

now you can specify the following: 
```javascript
ssv = {
...
layout: {
  x:{
    field: 'latitude'
  },
  y:{
    field: 'longitude'
  },
  geo:{
    level: 5,
    center: [39.5, -98.5]
  }
},
...
}
```

the initial viewport will be pointed to `layout.geo.center` at zoom level `layout.geo.level`. And an OpenStreet map background will be automatic rendered. 
