### PR TITLE
responsive & better-positioned kyrix buttons

### DIFF
--- a/back-end/src/main/java/index/Indexer.java
+++ b/back-end/src/main/java/index/Indexer.java
@@ -229,7 +229,7 @@ public abstract class Indexer implements Serializable {
             }
 
             // width
-            if (width_func.substring(0, 4).equals("full")) width_dbl = Double.MAX_VALUE;
+            if (width_func.substring(0, 4).equals("full")) width_dbl = Integer.MAX_VALUE;
             else if (width_func.substring(0, 3).equals("con"))
                 width_dbl = Double.parseDouble(width_func.substring(4));
             else {
@@ -239,7 +239,7 @@ public abstract class Indexer implements Serializable {
             }
 
             // height
-            if (height_func.substring(0, 4).equals("full")) height_dbl = Double.MAX_VALUE;
+            if (height_func.substring(0, 4).equals("full")) height_dbl = Integer.MAX_VALUE;
             else if (height_func.substring(0, 3).equals("con"))
                 height_dbl = Double.parseDouble(height_func.substring(4));
             else {

--- a/back-end/src/main/java/project/View.java
+++ b/back-end/src/main/java/project/View.java
@@ -4,7 +4,7 @@ package project;
 public class View {
 
     private String id;
-    private int minx, miny, width, height;
+    private int width, height;
     private String initialCanvasId;
     private int initialViewportX;
     private int initialViewportY;
@@ -12,14 +12,6 @@ public class View {
 
     public String getId() {
         return id;
-    }
-
-    public int getMinx() {
-        return minx;
-    }
-
-    public int getMiny() {
-        return miny;
     }
 
     public int getWidth() {
@@ -49,11 +41,7 @@ public class View {
     @Override
     public String toString() {
         return "View{"
-                + "minx="
-                + minx
-                + ", miny="
-                + miny
-                + ", width="
+                + "width="
                 + width
                 + ", height="
                 + height

--- a/compiler/examples/USMap_cmv/USMap_cmv.js
+++ b/compiler/examples/USMap_cmv/USMap_cmv.js
@@ -10,16 +10,10 @@ var p = new Project("usmap_cmv", "../../../config.txt");
 // ================== Views ===================
 var stateMapWidth = 2000;
 var stateMapHeight = 1000;
-var view = new View("state", 0, 0, stateMapWidth, stateMapHeight);
+var view = new View("state", stateMapWidth, stateMapHeight);
 p.addView(view);
 
-var rightView = new View(
-    "county",
-    stateMapWidth + 150,
-    0,
-    stateMapWidth,
-    stateMapHeight
-);
+var rightView = new View("county", stateMapWidth, stateMapHeight);
 p.addView(rightView);
 
 // specify args

--- a/compiler/examples/dots-pushdown-uniform/dots.js
+++ b/compiler/examples/dots-pushdown-uniform/dots.js
@@ -32,7 +32,7 @@ p.addCanvas(bottomCanvas);
 bottomCanvas.addLayer(dotsLayer);
 
 // ================== Views ===================
-var view = new View("dotview", 0, 0, 1000, 1000);
+var view = new View("dotview", 1000, 1000);
 p.addView(view);
 p.setInitialStates(view, topCanvas, 5000, 5000);
 

--- a/compiler/examples/dots-skewed-80-20/dots.js
+++ b/compiler/examples/dots-skewed-80-20/dots.js
@@ -32,7 +32,7 @@ p.addCanvas(bottomCanvas);
 bottomCanvas.addLayer(dotsLayer);
 
 // ================== Views ===================
-var view = new View("dotview", 0, 0, 1000, 1000);
+var view = new View("dotview", 1000, 1000);
 p.addView(view);
 p.setInitialStates(view, topCanvas, 5000, 5000);
 

--- a/compiler/examples/dots-uniform/dots.js
+++ b/compiler/examples/dots-uniform/dots.js
@@ -34,7 +34,7 @@ p.addCanvas(bottomCanvas);
 bottomCanvas.addLayer(dotsLayer);
 
 // ================== Views ===================
-var view = new View("dotview", 0, 0, 1000, 1000);
+var view = new View("dotview", 1000, 1000);
 p.addView(view);
 p.setInitialStates(view, topCanvas, 5000, 5000);
 

--- a/compiler/examples/flare/flare.js
+++ b/compiler/examples/flare/flare.js
@@ -23,7 +23,7 @@ flareCanvas.addLayer(flarePackLayer);
 flarePackLayer.addRenderingFunc(renderers.flarePackRendering);
 
 // ================== Views ===================
-var view = new View("flare", 0, 0, 1000, 1000);
+var view = new View("flare", 1000, 1000);
 p.addView(view);
 p.setInitialStates(view, flareCanvas, 0, 0, {
     layer0: {

--- a/compiler/examples/forest/forest.js
+++ b/compiler/examples/forest/forest.js
@@ -63,7 +63,7 @@ c3BackgroundLayer.addPlacement(placements.c3BackgroundPlacement);
 c3BackgroundLayer.addRenderingFunc(renderers.backgroundRendering);
 
 // ================== Views ===================
-var view = new View("forest", 0, 0, 1400, 800);
+var view = new View("forest", 1400, 800);
 p.addView(view);
 p.setInitialStates(view, c1BackgroundCanvas, 0, 0);
 

--- a/compiler/examples/nba/nba.js
+++ b/compiler/examples/nba/nba.js
@@ -89,7 +89,7 @@ statsLayer.addPlacement(placements.boxscorePlacement);
 statsLayer.addRenderingFunc(renderers.boxscoreStatsRendering);
 
 // ================== Views ===================
-var view = new View("nba", 0, 0, 1000, 1000);
+var view = new View("nba", 1000, 1000);
 p.addView(view);
 p.setInitialStates(view, teamLogoCanvas, 0, 0);
 

--- a/compiler/examples/nba_cmv/nba_cmv.js
+++ b/compiler/examples/nba_cmv/nba_cmv.js
@@ -90,11 +90,11 @@ statsLayer.addPlacement(placements.boxscorePlacement);
 statsLayer.addRenderingFunc(renderers.boxscoreStatsRendering);
 
 // ================== Views ===================
-var leftView = new View("left", 0, 0, 1000, 1000);
+var leftView = new View("left", 1000, 1000);
 p.addView(leftView);
 p.setInitialStates(leftView, teamLogoCanvas, 0, 0);
 
-var rightView = new View("right", 1100, 0, 1000, 1000);
+var rightView = new View("right", 1000, 1000);
 p.addView(rightView);
 
 // ================== teamlogo -> teamtimeline (load) ===================

--- a/compiler/src/View.js
+++ b/compiler/src/View.js
@@ -1,26 +1,18 @@
 /**
  * Construct a view object
  * @param viewId - identifier of this view
- * @param minx - the minimum x coordinate of the this view inside the view coordinate system
- * @param miny - the minimum y coordinate of the this view inside the view coordinate system
  * @param width - width of this view
  * @param height - height of this view
  * @constructor
  */
-function View(viewId, minx, miny, width, height) {
+function View(viewId, width, height) {
     if (viewId == null) throw new Error("Constructing View: invalid view Id");
-    if (minx == null || minx < 0)
-        throw new Error("Constructing View: invalid minx.");
-    if (minx == null || miny < 0)
-        throw new Error("Constructing View: invalid miny.");
     if (width == null || width <= 0)
         throw new Error("Constructing View: invalid width.");
     if (height == null || height <= 0)
         throw new Error("Constructing View: invalid height.");
 
     this.id = viewId;
-    this.minx = minx;
-    this.miny = miny;
     this.width = width;
     this.height = height;
     this.initialCanvasId = "";

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -61,21 +61,9 @@ function Project(name, configFile) {
 
 // Add a view to a project.
 function addView(view) {
-    for (var i = 0; i < this.views.length; i++) {
+    for (var i = 0; i < this.views.length; i++)
         if (this.views[i].id == view.id)
             throw new Error("Adding View: view id already existed.");
-        if (
-            this.views[i].minx > view.minx + view.width ||
-            this.views[i].miny > view.miny + view.height ||
-            view.minx > this.views[i].minx + this.views[i].width ||
-            view.miny > this.views[i].miny + this.views[i].height
-        )
-            continue;
-        else
-            throw new Error(
-                "Adding View: this view intersects with an existing view."
-            );
-    }
     this.views.push(view);
 }
 
@@ -242,8 +230,6 @@ function addTable(table, args) {
     if (!args.view) {
         var tableView = new View(
             table.name + "_view",
-            0,
-            0,
             Math.floor(table.sum_width * 0.8),
             700
         );
@@ -431,13 +417,7 @@ function addSSV(ssv, args) {
     // create a new view if not specified
     if (!args.view) {
         var viewId = "ssv" + (this.ssvs.length - 1);
-        var view = new View(
-            viewId,
-            0,
-            0,
-            ssv.topLevelWidth,
-            ssv.topLevelHeight
-        );
+        var view = new View(viewId, ssv.topLevelWidth, ssv.topLevelHeight);
         this.addView(view);
         // initialize view
         this.setInitialStates(view, curPyramid[0], 0, 0);
@@ -527,8 +507,6 @@ function addUSMap(usmap, args) {
     if (!("view" in args)) {
         var view = new View(
             "usmap" + (this.usmaps.length - 1),
-            0,
-            0,
             usmap.stateMapWidth,
             usmap.stateMapHeight
         );

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -1,5 +1,9 @@
 <html>
-    <body></body>
+    <body>
+        <div>
+            <!-- kyrix div -->
+        </div>
+    </body>
     <head>
         <meta name="referrer" content="no-referrer" />
         <link rel="stylesheet" type="text/css" href="/static/css/main.css" />
@@ -33,7 +37,15 @@
         <script src="/js/jump.js"></script>
         <script src="/js/staticLayers.js"></script>
         <script>
-            $(document).ready(pageOnLoad());
+            $(document).ready(
+                pageOnLoad(
+                    "",
+                    d3
+                        .select("body")
+                        .select("div")
+                        .node()
+                )
+            );
         </script>
     </head>
 </html>

--- a/front-end/js/embed/API.js
+++ b/front-end/js/embed/API.js
@@ -1,7 +1,7 @@
-// initialize app, pass in server url (and possibly app name in the future)
-// return a div that kyrix vis is contained in
-export function initializeApp(serverAddr) {
-    return pageOnLoad(serverAddr);
+// initialize app, pass in server url and a div for holding kyrix vis
+// return a promise that resolves when kyrix loads
+export function initializeApp(serverAddr, kyrixDiv) {
+    return pageOnLoad(serverAddr, kyrixDiv);
 }
 
 export function filteredNodes(viewId, layerId, filterFunc) {

--- a/front-end/js/embed/example_nba.html
+++ b/front-end/js/embed/example_nba.html
@@ -6,6 +6,7 @@
             Filter team that starts with:
             <input type="text" id="test_input" name="filter" value="" /><br />
         </div>
+        <div class="kyrixdiv"></div>
     </body>
     <head>
         <link
@@ -39,7 +40,7 @@
             var serverAddr = "http://127.0.0.1:8000";
 
             // initializeApp() loads kyrix vis into a div, and returns this div
-            kyrix.initializeApp(serverAddr);
+            kyrix.initializeApp(serverAddr, d3.select(".kyrixdiv").node());
 
             // logs to console every time a jump is finished
             kyrix.on("jumpstart", "nba", function() {

--- a/front-end/js/embed/example_usmap.html
+++ b/front-end/js/embed/example_usmap.html
@@ -1,7 +1,9 @@
 <html>
     <body>
         <div id="controldiv"></div>
-        <div id="kyrixcontainer"></div>
+        <div id="kyrixcontainer">
+            <div></div>
+        </div>
     </body>
     <head>
         <link
@@ -35,9 +37,13 @@
             var serverAddr = "http://127.0.0.1:8000";
 
             // initializeApp() loads kyrix vis into a div, and returns this div
-            d3.select("#kyrixcontainer")
-                .node()
-                .appendChild(kyrix.initializeApp(serverAddr));
+            kyrix.initializeApp(
+                serverAddr,
+                d3
+                    .select("#kyrixcontainer")
+                    .select("div")
+                    .node()
+            );
 
             //--------------------------US Map-------------------------
             //pan by arrow

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -375,29 +375,32 @@ function registerJumps(viewId, svg, layerId) {
             // create a jumpoption popover using bootstrap
             d3.select("body")
                 .append("div")
-                .classed("view_" + viewId + " popover fade right in", true)
+                .classed(
+                    "view_" + viewId + " jumppopover popover fade right in",
+                    true
+                )
                 .attr("role", "tooltip")
-                .attr("id", "jumppopover")
                 .append("div")
-                .classed("view_" + viewId + " arrow popoverarrow", true)
-                .attr("id", "popoverarrow");
-            d3.select(viewClass + "#jumppopover")
+                .classed("view_" + viewId + " popoverarrow arrow", true);
+            d3.select(viewClass + ".jumppopover")
                 .append("h2")
                 .classed("view_" + viewId + " popover-title", true)
-                .attr("id", "popovertitle")
                 .html("Jump Options")
                 .append("a")
-                .classed("view_" + viewId + " close", true)
+                .classed("view_" + viewId + " popoverclose close", true)
                 .attr("href", "#")
-                .attr("id", "popoverclose")
                 .html("&times;")
                 .on("click", function() {
                     removePopovers(viewId);
                 });
-            d3.select(viewClass + "#jumppopover")
+            d3.select(viewClass + ".jumppopover")
                 .append("div")
-                .classed("view_" + viewId + " popover-content list-group", true)
-                .attr("id", "popovercontent");
+                .classed(
+                    "view_" +
+                        viewId +
+                        " popovercontent popover-content list-group",
+                    true
+                );
 
             // add jump options
             for (var k = 0; k < jumps.length; k++) {
@@ -416,7 +419,7 @@ function registerJumps(viewId, svg, layerId) {
                 )
                     continue;
 
-                // create table cell and append it to #popovercontent
+                // create table cell and append it to .popovercontent
                 var optionText = "<b>ZOOM IN </b>";
                 if (jumps[k].type == param.load)
                     optionText =
@@ -432,7 +435,7 @@ function registerJumps(viewId, svg, layerId) {
                         ? jumps[k].name
                         : jumps[k].name.parseFunction()(d, optionalArgs);
                 var jumpOption = d3
-                    .select(viewClass + "#popovercontent")
+                    .select(viewClass + ".popovercontent")
                     .append("a")
                     .classed("list-group-item", true)
                     .attr("href", "#")
@@ -450,10 +453,10 @@ function registerJumps(viewId, svg, layerId) {
 
             // position jump popover according to event x/y and its width/height
             var popoverHeight = d3
-                .select(viewClass + "#jumppopover")
+                .select(viewClass + ".jumppopover")
                 .node()
                 .getBoundingClientRect().height;
-            d3.select(viewClass + "#jumppopover")
+            d3.select(viewClass + ".jumppopover")
                 .style("left", d3.event.pageX + "px")
                 .style("top", d3.event.pageY - popoverHeight / 2 + "px");
         });

--- a/front-end/js/jump.js
+++ b/front-end/js/jump.js
@@ -373,7 +373,7 @@ function registerJumps(viewId, svg, layerId) {
             removePopovers(viewId);
 
             // create a jumpoption popover using bootstrap
-            d3.select(".kyrixdiv")
+            d3.select("body")
                 .append("div")
                 .classed("view_" + viewId + " popover fade right in", true)
                 .attr("role", "tooltip")
@@ -453,16 +453,9 @@ function registerJumps(viewId, svg, layerId) {
                 .select(viewClass + "#jumppopover")
                 .node()
                 .getBoundingClientRect().height;
-            var kyrixDivBox = d3
-                .select(".kyrixdiv")
-                .node()
-                .getBoundingClientRect();
             d3.select(viewClass + "#jumppopover")
-                .style("left", d3.event.pageX - kyrixDivBox.left + "px")
-                .style(
-                    "top",
-                    d3.event.pageY - kyrixDivBox.top - popoverHeight / 2 + "px"
-                );
+                .style("left", d3.event.pageX + "px")
+                .style("top", d3.event.pageY - popoverHeight / 2 + "px");
         });
     });
 }

--- a/front-end/js/jumpAnimation.js
+++ b/front-end/js/jumpAnimation.js
@@ -53,7 +53,7 @@ function animateSemanticZoom(viewId, jump, newVpX, newVpY, tuple) {
                 // because here we use client coordinates to infer svg coordinates,
                 // we need to multiply a scale factor
                 // which is how much the svg viewport has been scaled,
-                // which equals to curViewport[2] / containerW (see comments in zoomButton.js)
+                // which equals to curViewport[2] / containerW
                 var containerW = d3.select("#containerSvg").attr("width");
                 var curViewport = d3.select("#containerSvg").attr("viewBox");
                 var curViewportW =

--- a/front-end/js/jumpAnimation.js
+++ b/front-end/js/jumpAnimation.js
@@ -53,14 +53,14 @@ function animateSemanticZoom(viewId, jump, newVpX, newVpY, tuple) {
                 // because here we use client coordinates to infer svg coordinates,
                 // we need to multiply a scale factor
                 // which is how much the svg viewport has been scaled,
-                // which equals to curViewport[2] / containerW
-                var containerW = d3.select("#containerSvg").attr("width");
-                var curViewport = d3.select("#containerSvg").attr("viewBox");
+                // which equals to curViewport[2] / viewW
+                var viewW = d3.select(viewClass + ".viewsvg").attr("width");
+                var curViewport = d3
+                    .select(viewClass + ".viewsvg")
+                    .attr("viewBox");
                 var curViewportW =
-                    curViewport == null
-                        ? containerW
-                        : curViewport.split(" ")[2];
-                var m = curViewportW / containerW;
+                    curViewport == null ? viewW : curViewport.split(" ")[2];
+                var m = curViewportW / viewW;
 
                 // now get minx, miny, maxx, maxy
                 minx = Math.min(minx, dx * m);

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -139,43 +139,41 @@ function processStyles() {
     }
 }
 
-// resize container svg to fit viewbox in kyrixdiv bounds
-function resizeKyrixSvg() {
-    // get containerSvg size
-    var containerW = d3.select("#containerSvg").attr("width");
-    var containerH = d3.select("#containerSvg").attr("height");
+// resize kyrix vis to fit in vis div bounds
+// also, call drawZoomButton to make buttons smaller/bigger
+function resizeKyrixStuff(viewId) {
+    drawZoomButtons(viewId);
 
-    // Update all elements of class kyrixdiv
-    var divs = document.getElementsByClassName("kyrixdiv");
-    for (var i = divs.length - 1; i >= 0; i--) {
-        var div = divs[i];
+    // for vis
+    var viewClass = ".view_" + viewId;
+    var div = d3.select(viewClass + ".kyrixvisdiv");
 
-        // maximum space allowed in the div
-        var bbox = div.getBoundingClientRect();
-        var maxW = bbox.width - param.buttonAreaWidth;
-        var maxH = bbox.height; // top margin == 0
+    // maximum space allowed in the div
+    var bbox = div.node().getBoundingClientRect();
+    var maxW = bbox.width;
+    var maxH = bbox.height;
 
-        // maximum space according to the ratio of container svg
-        var realW = Math.min(maxW, (maxH * containerW) / containerH);
-        var realH = (realW * containerH) / containerW;
+    // user-specified width/height
+    var viewSvg = d3.select(viewClass + ".viewsvg");
+    var viewWidth = viewSvg.attr("width");
+    var viewHeight = viewSvg.attr("height");
 
-        // set viewbox accordingly
-        var svg = div.firstElementChild;
-        svg.setAttribute(
-            "viewBox",
-            "0 0 " +
-                (containerW * containerW) / realW +
-                " " +
-                (containerH * containerH) / realH
-        );
-    }
+    // maximum space according to the ratio of view svg
+    var realW = Math.min(maxW, (maxH * viewWidth) / viewHeight);
+    var realH = (realW * viewHeight) / viewWidth;
+
+    // set viewbox accordingly
+    div.select("svg").attr(
+        "viewBox",
+        "0 0 " +
+            (viewWidth * viewWidth) / realW +
+            " " +
+            (viewHeight * viewHeight) / realH
+    );
 }
 
 // set up page
-function pageOnLoad(serverAddr) {
-    // this function can only be called once
-    if (globalVar.serverAddr != "N/A")
-        throw new Error("kyrix initialized already!");
+function pageOnLoad(serverAddr, kyrixRawDiv) {
     if (serverAddr != null) {
         // get rid of the last '/'
         if (serverAddr[serverAddr.length - 1] == "/")
@@ -184,10 +182,7 @@ function pageOnLoad(serverAddr) {
     } else globalVar.serverAddr = "";
 
     // create a div where kyrix vis lives in
-    var kyrixDiv = d3
-        .select("body")
-        .append("div")
-        .classed("kyrixdiv", true);
+    var kyrixDiv = d3.select(kyrixRawDiv).classed("kyrixdiv", true);
 
     // get information about the first canvas to render
     $.ajax({
@@ -224,44 +219,37 @@ function pageOnLoad(serverAddr) {
             d3.select(window).on("resize.popover", removePopovers);
             //d3.select(window).on("click", removePopovers);
 
-            // set up container SVG
-            var containerW = 0,
-                containerH = 0;
+            // create view layouts
             var viewSpecs = globalVar.project.views;
-            for (var i = 0; i < viewSpecs.length; i++) {
-                containerW = Math.max(
-                    containerW,
-                    viewSpecs[i].minx +
-                        viewSpecs[i].width +
-                        param.viewPadding * 2
-                );
-                containerH = Math.max(
-                    containerH,
-                    viewSpecs[i].miny +
-                        viewSpecs[i].height +
-                        param.viewPadding * 2
-                );
-            }
-
-            // Set kyrixDiv max size (don't allow div to get bigger than svg)
-            kyrixDiv
-                .style("max-width", containerW + param.buttonAreaWidth + "px")
-                .style("max-height", containerH + "px");
-
-            // Create container svg and set its top-left corner at (0, 90) in kyrixDiv
-            kyrixDiv
-                .append("svg")
-                .attr("id", "containerSvg")
-                .style("top", "0px") // top margin = 0
-                .style("left", param.buttonAreaWidth + "px") // left margin == 20 + button_width + 20
-                .attr("width", containerW)
-                .attr("height", containerH);
-
             for (var i = 0; i < viewSpecs.length; i++) {
                 // get a reference for current globalvar dict
                 var viewId = viewSpecs[i].id;
                 globalVar.views[viewId] = {};
                 var gvd = globalVar.views[viewId];
+
+                // create a view div, a button div and a vis div
+                var viewDiv = kyrixDiv
+                    .append("div")
+                    .classed("kyrixviewdiv", true)
+                    .classed("view_" + viewId, true);
+                var buttonDiv = viewDiv
+                    .append("div")
+                    .classed("kyrixbuttondiv", true)
+                    .classed("view_" + viewId, true);
+                var visDiv = viewDiv
+                    .append("div")
+                    .classed("kyrixvisdiv", true)
+                    .classed("view_" + viewId, true);
+
+                // make things responsive
+                new ResizeSensor(
+                    visDiv.node(),
+                    (function(viewId) {
+                        return function() {
+                            resizeKyrixStuff(viewId);
+                        };
+                    })(viewId)
+                );
 
                 // initial setup
                 gvd.initialViewportX = viewSpecs[i].initialViewportX;
@@ -288,12 +276,19 @@ function pageOnLoad(serverAddr) {
                         else gvd.predicates.push({});
                 }
 
+                // Set kyrixDiv max size (don't allow div to get bigger than svg)
+                var visWidth = gvd.viewportWidth + param.viewPadding * 2;
+                var visHeight = gvd.viewportHeight + param.viewPadding * 2;
+                // visDiv
+                //     .style("max-width", visWidth + "px")
+                //     .style("max-height",visHeight + "px");
+
                 // set up view svg
-                d3.select("#containerSvg")
+                visDiv
                     .append("svg")
                     .classed("view_" + viewId + " viewsvg", true)
-                    .attr("width", gvd.viewportWidth + param.viewPadding * 2)
-                    .attr("height", gvd.viewportHeight + param.viewPadding * 2)
+                    .attr("width", visWidth)
+                    .attr("height", visHeight)
                     .attr("x", viewSpecs[i].minx)
                     .attr("y", viewSpecs[i].miny)
                     .append("g")
@@ -349,12 +344,6 @@ function pageOnLoad(serverAddr) {
                 }
             }
         }
-    });
-
-    // add resize event listener to kyrixdiv
-    new ResizeSensor(kyrixDiv.node(), function() {
-        resizeKyrixSvg();
-        for (var viewId in globalVar.views) drawZoomButtons(viewId);
     });
 
     // return div node instead of selection

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -185,7 +185,8 @@ function pageOnLoad(serverAddr, kyrixRawDiv) {
     var kyrixDiv = d3.select(kyrixRawDiv).classed("kyrixdiv", true);
 
     // get information about the first canvas to render
-    $.ajax({
+    // and return a promise representing whether kyrix is loaded
+    return $.ajax({
         type: "GET",
         url: globalVar.serverAddr + "/first",
         data: {},
@@ -276,7 +277,7 @@ function pageOnLoad(serverAddr, kyrixRawDiv) {
                         else gvd.predicates.push({});
                 }
 
-                // Set kyrixDiv max size (don't allow div to get bigger than svg)
+                // Set viewdiv max size (don't allow div to get bigger than svg)
                 var visWidth = gvd.viewportWidth + param.viewPadding * 2;
                 var visHeight = gvd.viewportHeight + param.viewPadding * 2;
                 // visDiv
@@ -345,7 +346,4 @@ function pageOnLoad(serverAddr, kyrixRawDiv) {
             }
         }
     });
-
-    // return div node instead of selection
-    return kyrixDiv.node();
 }

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -170,6 +170,11 @@ function resizeKyrixStuff(viewId) {
             " " +
             (viewHeight * viewHeight) / realH
     );
+
+    // center
+    viewSvg
+        .style("left", bbox.width / 2 - realW / 2)
+        .style("top", bbox.height / 2 - realH / 2);
 }
 
 // set up page

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -163,7 +163,7 @@ function resizeKyrixStuff(viewId) {
     var realH = (realW * viewHeight) / viewWidth;
 
     // set viewbox accordingly
-    div.select("svg").attr(
+    viewSvg.attr(
         "viewBox",
         "0 0 " +
             (viewWidth * viewWidth) / realW +

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -277,7 +277,7 @@ function pageOnLoad(serverAddr, kyrixRawDiv) {
                         else gvd.predicates.push({});
                 }
 
-                // Set viewdiv max size (don't allow div to get bigger than svg)
+                // Set  max size (don't allow div to get bigger than svg)
                 var visWidth = gvd.viewportWidth + param.viewPadding * 2;
                 var visHeight = gvd.viewportHeight + param.viewPadding * 2;
                 // visDiv

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -277,9 +277,9 @@ function pageOnLoad(serverAddr, kyrixRawDiv) {
                         else gvd.predicates.push({});
                 }
 
-                // Set  max size (don't allow div to get bigger than svg)
                 var visWidth = gvd.viewportWidth + param.viewPadding * 2;
                 var visHeight = gvd.viewportHeight + param.viewPadding * 2;
+                // Set  max size (don't allow div to get bigger than svg)
                 // visDiv
                 //     .style("max-width", visWidth + "px")
                 //     .style("max-height",visHeight + "px");

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -218,7 +218,7 @@ function pageOnLoad(serverAddr, kyrixRawDiv) {
 
             // remove all jump option popovers when the window is resized
             d3.select(window).on("resize.popover", removePopovers);
-            //d3.select(window).on("click", removePopovers);
+            d3.select(window).on("click", removePopovers);
 
             // create view layouts
             var viewSpecs = globalVar.project.views;

--- a/front-end/js/parameter.js
+++ b/front-end/js/parameter.js
@@ -42,8 +42,8 @@ param.dimOpacity = 0.4;
 // extra tiles per dimension
 param.extraTiles = 0;
 
-// padding for the container svg
-param.viewPadding = 100;
+// padding for .viewsvg
+param.viewPadding = 70;
 
 // jump types
 param.literalZoomIn = "literal_zoom_in";

--- a/front-end/js/zoomButton.js
+++ b/front-end/js/zoomButton.js
@@ -5,67 +5,53 @@ function drawZoomButtons(viewId) {
 
     // create buttons if not existed
     if (d3.select(viewClass + ".gobackbutton").empty())
-        d3.select(".kyrixdiv")
+        d3.select(viewClass + ".kyrixbuttondiv")
             .append("button")
             .classed("view_" + viewId + " gobackbutton", true)
             .attr("disabled", "true")
             .classed("btn", true)
             .classed("btn-default", true)
-            .classed("btn-lg", true)
             .html('<span class="glyphicon glyphicon-arrow-left"></span>');
     if (d3.select(viewClass + ".zoominbutton").empty())
-        d3.select(".kyrixdiv")
+        d3.select(viewClass + ".kyrixbuttondiv")
             .append("button")
             .classed("view_" + viewId + " zoominbutton", true)
             .attr("disabled", "true")
             .classed("btn", true)
             .classed("btn-default", true)
-            .classed("btn-lg", true)
             .html('<span class="glyphicon glyphicon-zoom-in"></span>');
     if (d3.select(viewClass + ".zoomoutbutton").empty())
-        d3.select(".kyrixdiv")
+        d3.select(viewClass + ".kyrixbuttondiv")
             .append("button")
             .classed("view_" + viewId + " zoomoutbutton", true)
             .attr("disabled", "true")
             .classed("btn", true)
             .classed("btn-default", true)
-            .classed("btn-lg", true)
             .html('<span class="glyphicon glyphicon-zoom-out"></span>');
 
-    // position the buttons at fixed positions in the top-left of the kyrixdiv
+    // deciding button size according to vis size
     var bbox = d3
-        .select("#containerSvg")
+        .select(viewClass + ".kyrixviewdiv")
         .node()
         .getBoundingClientRect();
-
-    // in pageOnLoad.js, we have curViewport[2] = (containerW * containerW) / realW
-    // realW / containerW = (containerW * containerW) / curViewport[2] / containerW
-    //                    = containerW / curViewport[2]
-    var containerW = d3.select("#containerSvg").attr("width");
-    var curViewport = d3.select("#containerSvg").attr("viewBox");
-    var curViewportW;
-    if (curViewport == null) curViewportW = containerW;
-    else curViewportW = curViewport.split(" ")[2];
-    var bLeft =
-        +bbox.left +
-        (+d3.select(viewClass + ".viewsvg").attr("x") * containerW) /
-            curViewportW;
-    var bTop =
-        +bbox.top +
-        (+(+d3.select(viewClass + ".viewsvg").attr("y")) * containerW) /
-            curViewportW;
-    var leftMargin = 50;
-    var topMargin = 80;
-    var dist = 50;
-    d3.select(viewClass + ".gobackbutton")
-        .style("top", bTop + topMargin + "px")
-        .style("left", bLeft - leftMargin + "px");
-    d3.select(viewClass + ".zoominbutton")
-        .style("top", bTop + topMargin + dist + "px")
-        .style("left", bLeft - leftMargin + "px");
-    d3.select(viewClass + ".zoomoutbutton")
-        .style("top", bTop + topMargin + dist * 2 + "px")
-        .style("left", bLeft - leftMargin + "px");
+    var minSize = Math.min(bbox.width, bbox.height);
+    var sizeThresholds = [400, 800, 1200];
+    var sizeClasses = ["btn-xs", "btn-sm", ""];
+    var sizeClass = "btn-lg";
+    for (var i = 0; i < sizeThresholds.length; i++)
+        if (minSize <= sizeThresholds[i]) {
+            sizeClass = sizeClasses[i];
+            break;
+        }
+    d3.selectAll(viewClass + ".kyrixbuttondiv button")
+        .classed("btn-xs", false)
+        .classed("btn-sm", false)
+        .classed("btn-lg", false);
+    if (sizeClass != "")
+        d3.selectAll(viewClass + ".kyrixbuttondiv button").classed(
+            sizeClass,
+            true
+        );
 }
 
 // called after a new canvas is completely rendered

--- a/front-end/static/css/main.css
+++ b/front-end/static/css/main.css
@@ -34,8 +34,7 @@ body {
 
 .viewsvg {
     display: block;
-    margin-top: 5px;
-    margin-left: 5px;
+    position: relative;
 }
 
 div.jumppopover {

--- a/front-end/static/css/main.css
+++ b/front-end/static/css/main.css
@@ -39,6 +39,7 @@ body {
 }
 
 #jumppopover {
+    position: absolute;
     display: block;
     opacity: 0.9;
 }

--- a/front-end/static/css/main.css
+++ b/front-end/static/css/main.css
@@ -38,33 +38,33 @@ body {
     margin-left: 5px;
 }
 
-#jumppopover {
+div.jumppopover {
     position: absolute;
     display: block;
     opacity: 0.9;
 }
 
-#popoverarrow {
+div.popoverarrow {
     top: 50%;
 }
 
-#popoverclose {
+a.popoverclose {
     position: relative;
     bottom: 5px;
     left: 6px;
 }
 
-#popovercontent {
+div.popovercontent {
     margin: 0px;
     padding: 0px;
 }
 
-#popovercontent > .list-group-item {
+div.popovercontent > .list-group-item {
     padding: 6px;
     border: none;
 }
 
-#jumppopover > div {
+div.jumppopover > div {
     text-align: center;
     font-family: "Source Serif Pro", sans-serif !important;
 }

--- a/front-end/static/css/main.css
+++ b/front-end/static/css/main.css
@@ -4,20 +4,38 @@ body {
 }
 
 .kyrixdiv {
-    overflow: hidden;
     width: 100%;
     height: 100%;
+    display: flex;
+    overflow: hidden;
 }
 
-#containerSvg {
+.kyrixviewdiv {
+    height: 100%;
+    display: flex;
+    overflow: hidden;
+}
+
+.kyrixvisdiv {
+    flex: 1 1 0;
+    overflow: hidden;
+}
+
+.kyrixbuttondiv {
+    width: auto;
+    height: auto;
+    overflow: hidden;
+}
+
+.kyrixbuttondiv button {
     display: block;
-    position: absolute;
-    margin: auto;
+    margin: 6px;
 }
 
 .viewsvg {
     display: block;
-    margin: auto;
+    margin-top: 5px;
+    margin-left: 5px;
 }
 
 #jumppopover {
@@ -48,16 +66,4 @@ body {
 #jumppopover > div {
     text-align: center;
     font-family: "Source Serif Pro", sans-serif !important;
-}
-
-.gobackbutton {
-    position: absolute;
-}
-
-.zoominbutton {
-    position: absolute;
-}
-
-.zoomoutbutton {
-    position: absolute;
 }


### PR DESCRIPTION
Used simple css to make button size responsive w.r.t to window size. Now buttons occupy less white space when the kyrix vis is small. 
![ddd](https://media.giphy.com/media/oX3PHgvDmhpGCAtsaS/giphy.gif)

Also, restructured the frontend to make the positioning of kyrix buttons better, especially when there are multiple views. Now Kyrix frontend handles the positioning of the views, so views don't need to be specified with awkward positioning coordinates. 

Also fixed a bunch other css issues (e.g. avoided using id based rules, no max-width for kyrix div, etc). 


