### PR TITLE
fixed bugs when running in Firefox

### DIFF
--- a/back-end/src/main/java/server/IndexHandler.java
+++ b/back-end/src/main/java/server/IndexHandler.java
@@ -46,6 +46,13 @@ public class IndexHandler implements HttpHandler {
             else if (path.contains(".jpg"))
                 Server.sendResponse(
                         httpExchange, HttpsURLConnection.HTTP_OK, content, len, "image/jpg");
+            else if (path.contains(".js"))
+                Server.sendResponse(
+                        httpExchange,
+                        HttpsURLConnection.HTTP_OK,
+                        content,
+                        len,
+                        "application/javascript");
             else Server.sendResponse(httpExchange, HttpsURLConnection.HTTP_OK, content, len);
         } catch (Exception e) {
             e.printStackTrace();

--- a/back-end/src/main/java/server/Server.java
+++ b/back-end/src/main/java/server/Server.java
@@ -281,6 +281,7 @@ public class Server {
             httpExchange.sendResponseHeaders(HttpsURLConnection.HTTP_NO_CONTENT, -1);
             return;
         }
+        httpExchange.getResponseHeaders().add("Content-Type", "text/plain");
         sendResponse(httpExchange, responseCode, response.getBytes(), response.getBytes().length);
     }
 

--- a/compiler/src/template-api/StaticAggregation.js
+++ b/compiler/src/template-api/StaticAggregation.js
@@ -995,7 +995,7 @@ function getRenderer(type) {
                         return (
                             ((d.kyrixBarCurH - d.kyrixAggValue) /
                                 d.kyrixBarTotalH) *
-                            500
+                            800
                         );
                     })
                     .duration(function(d) {

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -6,6 +6,7 @@
     </body>
     <head>
         <meta name="referrer" content="no-referrer" />
+        <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="/static/css/main.css" />
         <link
             rel="stylesheet"

--- a/front-end/js/pageOnLoad.js
+++ b/front-end/js/pageOnLoad.js
@@ -173,8 +173,8 @@ function resizeKyrixStuff(viewId) {
 
     // center
     viewSvg
-        .style("left", bbox.width / 2 - realW / 2)
-        .style("top", bbox.height / 2 - realH / 2);
+        .style("left", bbox.width / 2 - realW / 2 + "px")
+        .style("top", bbox.height / 2 - realH / 2 + "px");
 }
 
 // set up page


### PR DESCRIPTION
- css styles: add "`px`" where needed (without "px" things worked in both Chrome and Safari, but not Firefox)
- made backend always send back MIME-type, suppressing annoying Firefox warnings

tested w/ Firefox 83.0