### PR TITLE
JSON schema for Kyrix-S grammar

### DIFF
--- a/compiler/examples/template-api-examples/SSV_custom.js
+++ b/compiler/examples/template-api-examples/SSV_custom.js
@@ -44,8 +44,7 @@ var ssv = {
             }
         },
         hover: {
-            boundary: "convexhull",
-            selector: "*"
+            boundary: "convexhull"
         }
     },
     config: {

--- a/compiler/examples/template-api-examples/SSV_pie.js
+++ b/compiler/examples/template-api-examples/SSV_pie.js
@@ -73,7 +73,8 @@ var ssv = {
         topLevelHeight: 1000,
         axis: true,
         legendTitle: "Age Groups of Soccer Players in FIFA 2020",
-        legendDomain: ["Under 20", "Under 23", "Under 29", "Older"]
+        legendDomain: ["Under 20", "Under 23", "Under 29", "Older"],
+        numberFormat: ".2~s"
     }
 };
 

--- a/compiler/examples/template-api-examples/SSV_radar.js
+++ b/compiler/examples/template-api-examples/SSV_radar.js
@@ -77,7 +77,8 @@ var ssv = {
     config: {
         topLevelWidth: 1600,
         topLevelHeight: 1000,
-        axis: true
+        axis: true,
+        numberFormat: ".2~s"
     }
 };
 

--- a/compiler/package-lock.json
+++ b/compiler/package-lock.json
@@ -320,6 +320,11 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+        },
         "mysql": {
             "version": "2.15.0",
             "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.15.0.tgz",

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -22,9 +22,10 @@
     "license": "ISC",
     "devDependencies": {},
     "dependencies": {
+        "ajv": "^6.12.6",
         "d3": "^4.12.2",
+        "lodash.clonedeep": "^4.5.0",
         "mysql": "^2.15.0",
-        "pg": "^7.4.3",
-        "ajv": "^6.12.6"
+        "pg": "^7.4.3"
     }
 }

--- a/compiler/src/template-api/SSV.js
+++ b/compiler/src/template-api/SSV.js
@@ -29,6 +29,10 @@ function SSV(args_) {
     /*******************************************************************************
      * check constraints/add defaults that can't be easily expressed by json-schema
      *******************************************************************************/
+    // no limit in the query
+    if (args.data.query.toLowerCase().includes("limit"))
+        throw new Error("Constructing SSV: LIMIT is not allowed in data.query");
+
     // succinct object notation of the measures
     if (!("length" in args.marks.cluster.aggregate.measures)) {
         var measureArray = [];

--- a/compiler/src/template-api/SSV.js
+++ b/compiler/src/template-api/SSV.js
@@ -108,6 +108,7 @@ function SSV(args_) {
      * setting cluster params
      ************************/
     this.clusterParams = args.marks.cluster.config;
+    this.clusterParams.numberFormat = args.config.numberFormat;
 
     /********************************
      * setting aggregation parameters

--- a/compiler/src/template-api/SSV.js
+++ b/compiler/src/template-api/SSV.js
@@ -52,7 +52,6 @@ function SSV(args_) {
         args.marks.cluster.aggregate.measures = measureArray;
     }
 
-    // TODO: check that query doesn't have LIMIT
     if (
         (args.marks.cluster.mode == "circle" ||
             args.marks.cluster.mode == "heatmap" ||
@@ -289,9 +288,7 @@ function SSV(args_) {
         (this.loX = 0), (this.hiX = this.topLevelWidth);
         (this.loY = 0), (this.hiY = this.topLevelHeight);
     }
-    // TODO: check that if geo does not exist, map should be false
-    this.mapBackground =
-        "geo" in args.layout && ("map" in args.config ? args.config.map : true);
+    this.mapBackground = args.config.map;
     this.zoomFactor = args.config.zoomFactor;
     this.overlap =
         "overlap" in args.layout

--- a/compiler/src/template-api/SSV.js
+++ b/compiler/src/template-api/SSV.js
@@ -1,60 +1,37 @@
 const getBodyStringOfFunction = require("./Utilities").getBodyStringOfFunction;
-const setPropertiesIfNotExists = require("./Utilities")
-    .setPropertiesIfNotExists;
+const formatAjvErrorMessage = require("./Utilities").formatAjvErrorMessage;
+const fs = require("fs");
+const cloneDeep = require("lodash.clonedeep");
 
 /**
  * Constructor of an SSV object
  * @param args
  * @constructor
  */
-function SSV(args) {
-    if (args == null) args = {};
-
-    /******************************
-     * check clusterMode is correct
-     ******************************/
-    if (
-        !("marks" in args) ||
-        !"cluster" in args.marks ||
-        !("mode" in args.marks.cluster)
-    )
+function SSV(args_) {
+    // verify against schema
+    // defaults are assigned at the same time
+    var args = cloneDeep(args_);
+    var schema = JSON.parse(
+        fs.readFileSync("../../src/template-api/json-schema/SSV.json")
+    );
+    var ajv = new require("ajv")({useDefaults: true});
+    const CLASSES = {Function: Function};
+    ajv.addKeyword("instanceof", {
+        compile: schema => data => data instanceof CLASSES[schema]
+    });
+    var validator = ajv.compile(schema);
+    var valid = validator(args);
+    if (!valid)
         throw new Error(
-            "Constructing SSV: cluster mode (marks.cluster.mode) missing."
+            "Constructing SSV: " + formatAjvErrorMessage(validator.errors[0])
         );
-    var allClusterModes = new Set([
-        "custom",
-        "circle",
-        "contour",
-        "heatmap",
-        "radar",
-        "pie"
-    ]);
-    if (!allClusterModes.has(args.marks.cluster.mode))
-        throw new Error("Constructing SSV: unsupported cluster mode.");
 
-    /**************************************************************
-     * augment args with optional stuff that is omitted in the spec
-     **************************************************************/
-    if (!("config" in args)) args.config = {};
-    if (!("hover" in args.marks)) args.marks.hover = {};
-    if (!("legend" in args)) args.legend = {};
-    if (!("aggregate" in args.marks.cluster))
-        args.marks.cluster.aggregate = {dimensions: [], measures: []};
-    if (!("dimensions" in args.marks.cluster.aggregate))
-        args.marks.cluster.aggregate.dimensions = [];
-    if (!("measures" in args.marks.cluster.aggregate))
-        args.marks.cluster.aggregate.measures = [];
-
+    /************************************************************************
+     * check constraints/add defaults that can't be expressed by json-schema
+     ************************************************************************/
     // succinct object notation of the measures
     if (!("length" in args.marks.cluster.aggregate.measures)) {
-        if (
-            !("fields" in args.marks.cluster.aggregate.measures) ||
-            !("function" in args.marks.cluster.aggregate.measures)
-        )
-            throw new Error(
-                "Constructing SSV: fields or function not found" +
-                    "in the object notation of args.marks.cluster.aggregate.measures."
-            );
         var measureArray = [];
         for (
             var i = 0;
@@ -72,104 +49,15 @@ function SSV(args) {
         args.marks.cluster.aggregate.measures = measureArray;
     }
 
-    /*********************
-     * check required args
-     *********************/
-    var requiredArgs = [
-        ["data", "query"],
-        ["data", "db"],
-        ["layout", "x", "field"],
-        ["layout", "y", "field"],
-        ["layout", "z", "field"],
-        ["layout", "z", "order"]
-    ];
-    var requiredArgsTypes = [
-        "string",
-        "string",
-        "string",
-        "string",
-        "string",
-        "string"
-    ];
-    for (var i = 0; i < requiredArgs.length; i++) {
-        var curObj = args;
-        for (var j = 0; j < requiredArgs[i].length; j++)
-            if (!(requiredArgs[i][j] in curObj))
-                throw new Error(
-                    "Constructing SSV: " +
-                        requiredArgs[i].join(".") +
-                        " missing."
-                );
-            else curObj = curObj[requiredArgs[i][j]];
-        if (typeof curObj !== requiredArgsTypes[i])
-            throw new Error(
-                "Constructing SSV: " +
-                    requiredArgs[i].join(".") +
-                    " must be typed " +
-                    requiredArgsTypes[i] +
-                    "."
-            );
-        if (requiredArgsTypes[i] == "string")
-            if (curObj.length == 0)
-                throw new Error(
-                    "Constructing SSV: " +
-                        requiredArgs[i].join(".") +
-                        " cannot be an empty string."
-                );
-    }
-
-    /*******************
-     * other constraints
-     *******************/
-    if (
-        args.layout.x.extent != null &&
-        (!Array.isArray(args.layout.x.extent) ||
-            args.layout.x.extent.length != 2 ||
-            typeof args.layout.x.extent[0] != "number" ||
-            typeof args.layout.x.extent[1] != "number")
-    )
-        throw new Error("Constructing SSV: malformed x.extent");
-    if (
-        args.layout.y.extent != null &&
-        (!Array.isArray(args.layout.y.extent) ||
-            args.layout.y.extent.length != 2 ||
-            typeof args.layout.y.extent[0] != "number" ||
-            typeof args.layout.y.extent[1] != "number")
-    )
-        throw new Error("Constructing SSV: malformed y.extent");
-    if (args.layout.geo != null) {
-        if (!("level" in args.layout.geo))
-            throw new Error(
-                "Constructing SSV: zoom level needs to be specified in layout.geo."
-            );
-        if (!("center" in args.layout.geo))
-            throw new Error(
-                "Constructing SSV: viewport center needs to be specified in layout.geo."
-            );
+    // TODO: check that query doesn't have LIMIT
+    if ("geo" in args.layout) {
         if (args.layout.x.extent != null || args.layout.y.extent != null)
             throw new Error(
                 "Constructing SSV: extent shouldn't exist when layout.geo exists."
             );
-        if (args.layout.geo.level < 0 || args.layout.geo.level > 19)
-            throw new Error(
-                "Constructing SSV: geo initial zoom level must be between 0 and 19."
-            );
-        if (!Array.isArray(args.layout.geo.center))
-            throw new Error(
-                "Constructing SSV: geo center must be specified as an array with two float numbers."
-            );
-        if (
-            args.layout.geo.center[0] < -90 ||
-            args.layout.geo.center[0] > 90 ||
-            args.layout.geo.center[1] < -180 ||
-            args.layout.geo.center[1] > 180
-        )
-            throw new Error(
-                "Constructing SSV: invalid lat/lon specified in layout.geo.center."
-            );
     }
     if (
-        "axis" in args.marks &&
+        "axis" in args.config &&
         (args.layout.x.extent == null || args.layout.y.extent == null)
     )
         throw new Error(
@@ -204,26 +92,6 @@ function SSV(args) {
                 args.marks.cluster.mode +
                 " mode."
         );
-    for (var i = 0; i < args.marks.cluster.aggregate.dimensions.length; i++) {
-        if (!("field" in args.marks.cluster.aggregate.dimensions[i]))
-            throw new Error(
-                "Constructing SSV: field not found in aggregate dimensions."
-            );
-        if (!("domain" in args.marks.cluster.aggregate.dimensions[i]))
-            throw new Error(
-                "Constructing SSV: domain not found in aggregate dimensions."
-            );
-    }
-    for (var i = 0; i < args.marks.cluster.aggregate.measures.length; i++) {
-        if (!("field" in args.marks.cluster.aggregate.measures[i]))
-            throw new Error(
-                "Constructing SSV: field not found in aggregate measures."
-            );
-        if (!("function" in args.marks.cluster.aggregate.measures[i]))
-            throw new Error(
-                "Constructing SSV: function not found in aggregate measures."
-            );
-    }
     if (args.marks.cluster.mode == "radar")
         for (var i = 0; i < args.marks.cluster.aggregate.measures.length; i++)
             if (!("extent" in args.marks.cluster.aggregate.measures[i]))
@@ -242,18 +110,10 @@ function SSV(args) {
             throw new Error(
                 "Constructing SSV: rankList and tooltip cannot be specified together."
             );
-        if (!("mode" in args.marks.hover.rankList))
-            throw new Error(
-                "Constructing SSV: hover rankList mode (marks.hover.rankList.mode) is missing."
-            );
         if (args.marks.hover.rankList.mode == "custom") {
             if (!("custom" in args.marks.hover.rankList))
                 throw new Error(
                     "Constructing SSV: custom hover rankList renderer (marks.hover.rankList.custom) is missing."
-                );
-            if (typeof args.marks.hover.rankList.custom != "function")
-                throw new Error(
-                    "Constructing SSV: hover object renderer (marks.cluster.hover.rankList.custom) is not a function."
                 );
             if (
                 !("config" in args.marks.hover.rankList) ||
@@ -281,14 +141,6 @@ function SSV(args) {
     }
     if ("boundary" in args.marks.hover) {
         if (
-            !(args.marks.hover.boundary == "convexhull") &&
-            !(args.marks.hover.boundary == "bbox")
-        )
-            throw new Error(
-                "Constructing SSV: unrecognized hover boundary type " +
-                    args.marks.hover.boundary
-            );
-        if (
             args.marks.cluster.mode == "custom" &&
             !("selector" in args.marks.hover)
         )
@@ -297,69 +149,31 @@ function SSV(args) {
             );
     }
     if ("tooltip" in args.marks.hover) {
-        if (!("columns" in args.marks.hover.tooltip))
-            throw new Error(
-                "Constructing SSV: tooltip columns (marks.hover.tooltip.columns) missing."
-            );
-        if (!Array.isArray(args.marks.hover.tooltip.columns))
-            throw new Error(
-                "Constructing SSV: tooltip columns (marks.hover.tooltip.columns) must be an array."
-            );
         if (
             "aliases" in args.marks.hover.tooltip &&
-            !Array.isArray(args.marks.hover.tooltip.aliases)
+            args.marks.hover.tooltip.aliases.length !==
+                args.marks.hover.tooltip.columns.length
         )
             throw new Error(
-                "Constructing SSV: tooltip aliases (marks.hover.tooltip.aliases) must be an array."
+                "Constructing SSV: tooltip aliases (marks.hover.tooltip.aliases) " +
+                    "must have the same number of elements as columns (marks.hover.tooltip.columns)."
             );
+        // TODO repeated checks for selector in ranklist and boundary
     }
 
     /************************
      * setting generic params
      ************************/
     this.aggKeyDelimiter = "__";
-    this.loX = args.layout.x.extent != null ? args.layout.x.extent[0] : null;
-    this.loY = args.layout.y.extent != null ? args.layout.y.extent[0] : null;
-    this.hiX = args.layout.x.extent != null ? args.layout.x.extent[1] : null;
-    this.hiY = args.layout.y.extent != null ? args.layout.y.extent[1] : null;
+    this.loX = "extent" in args.layout.x ? args.layout.x.extent[0] : null;
+    this.loY = "extent" in args.layout.y ? args.layout.y.extent[0] : null;
+    this.hiX = "extent" in args.layout.x ? args.layout.x.extent[1] : null;
+    this.hiY = "extent" in args.layout.y ? args.layout.y.extent[1] : null;
 
     /************************
      * setting cluster params
      ************************/
-    this.clusterParams =
-        "config" in args.marks.cluster ? args.marks.cluster.config : {};
-    setPropertiesIfNotExists(this.clusterParams, {
-        numberFormat: ".2~s"
-    });
-    if (args.marks.cluster.mode == "circle")
-        setPropertiesIfNotExists(this.clusterParams, {
-            circleMinSize: 30,
-            circleMaxSize: 70
-        });
-    if (args.marks.cluster.mode == "contour")
-        setPropertiesIfNotExists(this.clusterParams, {
-            contourBandwidth: 30,
-            contourRadius: 30 * 4,
-            contourColorScheme: "interpolateViridis",
-            contourOpacity: 1
-        });
-    if (args.marks.cluster.mode == "heatmap")
-        setPropertiesIfNotExists(this.clusterParams, {
-            heatmapRadius: 80,
-            heatmapOpacity: 1
-        });
-    if (args.marks.cluster.mode == "radar")
-        setPropertiesIfNotExists(this.clusterParams, {
-            radarRadius: 80,
-            radarTicks: 5
-        });
-    if (args.marks.cluster.mode == "pie")
-        setPropertiesIfNotExists(this.clusterParams, {
-            pieInnerRadius: 1,
-            pieOuterRadius: 80,
-            pieCornerRadius: 5,
-            padAngle: 0.05
-        });
+    this.clusterParams = args.marks.cluster.config;
 
     /********************************
      * setting aggregation parameters
@@ -408,8 +222,7 @@ function SSV(args) {
     this.hoverParams = {};
     if ("rankList" in args.marks.hover) {
         // get in everything in config
-        if ("config" in args.marks.hover.rankList)
-            this.hoverParams = args.marks.hover.rankList.config;
+        this.hoverParams = args.marks.hover.rankList.config;
 
         // mode: currently either tabular or custom
         this.hoverParams.hoverRankListMode = args.marks.hover.rankList.mode;
@@ -425,27 +238,15 @@ function SSV(args) {
                 args.marks.hover.rankList.custom;
 
         // topk is 1 by default if unspecified
-        this.hoverParams.topk =
-            "topk" in args.marks.hover.rankList
-                ? args.marks.hover.rankList.topk
-                : 1;
+        this.hoverParams.topk = args.marks.hover.rankList.topk;
 
         // orientation of custom ranks
         this.hoverParams.hoverRankListOrientation =
-            "orientation" in args.marks.hover.rankList
-                ? args.marks.hover.rankList.orientation
-                : "vertical";
-
-        // less important cosmetic parameters are in marks.hover.rankList.config
-        // and we set default values here if unspecified:
-        setPropertiesIfNotExists(this.hoverParams, {
-            // hoverTableCellWidth: 100  <-- change
-            // hoverTableCellHeight: 50  <-- change
-        });
+            args.marks.hover.rankList.orientation;
     }
     if ("boundary" in args.marks.hover)
         this.hoverParams.hoverBoundary = args.marks.hover.boundary;
-    this.topk = this.hoverParams.topk != null ? this.hoverParams.topk : 0;
+    this.topk = "topk" in this.hoverParams ? this.hoverParams.topk : 0;
     this.hoverSelector =
         "selector" in args.marks.hover ? args.marks.hover.selector : null;
     this.tooltipColumns = this.tooltipAliases = null;
@@ -461,8 +262,7 @@ function SSV(args) {
      ***************************/
     // TODO: legend params for different templates
     this.legendParams = {};
-    this.legendParams.legendTitle =
-        "legendTitle" in args.config ? args.config.legendTitle : "Legend";
+    this.legendParams.legendTitle = args.config.legendTitle;
     if ("legendDomain" in args.config)
         this.legendParams.legendDomain = args.config.legendDomain;
 
@@ -470,7 +270,7 @@ function SSV(args) {
      * setting axis parameters
      ***************************/
     this.axisParams = {};
-    this.axis = "axis" in args.config ? args.config.axis : false;
+    this.axis = args.config.axis;
     this.axisParams.xAxisTitle =
         "xAxisTitle" in args.config
             ? args.config.xAxisTitle
@@ -546,19 +346,18 @@ function SSV(args) {
     }
     this.clusterCustomRenderer =
         "custom" in args.marks.cluster ? args.marks.cluster.custom : null;
-    this.columnNames = "columnNames" in args.data ? args.data.columnNames : [];
-    this.numLevels = "numLevels" in args.config ? args.config.numLevels : 10;
-    this.topLevelWidth =
-        "topLevelWidth" in args.config ? args.config.topLevelWidth : 1000;
-    this.topLevelHeight =
-        "topLevelHeight" in args.config ? args.config.topLevelHeight : 1000;
+    this.columnNames = args.data.columnNames;
+    this.numLevels = args.config.numLevels;
+    this.topLevelWidth = args.config.topLevelWidth;
+    this.topLevelHeight = args.config.topLevelHeight;
     if ("geo" in args.layout) {
         (this.loX = 0), (this.hiX = this.topLevelWidth);
         (this.loY = 0), (this.hiY = this.topLevelHeight);
     }
+    // TODO: check that if geo does not exist, map should be false
     this.mapBackground =
         "geo" in args.layout && ("map" in args.config ? args.config.map : true);
-    this.zoomFactor = "zoomFactor" in args.config ? args.config.zoomFactor : 2;
+    this.zoomFactor = args.config.zoomFactor;
     this.overlap =
         "overlap" in args.layout
             ? args.layout.overlap

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -466,7 +466,8 @@
                             "enum": ["bbox", "convexhull"]
                         },
                         "selector": {
-                            "$ref": "#/definitions/nonEmptyString"
+                            "$ref": "#/definitions/nonEmptyString",
+                            "default": "*"
                         }
                     },
                     "additionalProperties": false,
@@ -474,35 +475,7 @@
                 }
             },
             "required": ["cluster"],
-            "additionalProperties": false,
-            "allOf": [
-                {
-                    "if": {
-                        "properties": {
-                            "cluster": {
-                                "properties": {
-                                    "mode": {
-                                        "enum": ["custom"]
-                                    }
-                                }
-                            },
-                            "hover": {
-                                "anyOf": [
-                                    {"required": ["rankList"]},
-                                    {"required": ["boundary"]}
-                                ]
-                            }
-                        }
-                    },
-                    "then": {
-                        "properties": {
-                            "hover": {
-                                "required": ["selector"]
-                            }
-                        }
-                    }
-                }
-            ]
+            "additionalProperties": false
         },
         "config": {
             "type": "object",

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -119,7 +119,32 @@
                 }
             },
             "required": ["x", "y", "z"],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "required": ["geo"]
+                    },
+                    "then": {
+                        "properties": {
+                            "x": {
+                                "properties": {
+                                    "extent": {
+                                        "type": "null"
+                                    }
+                                }
+                            },
+                            "y": {
+                                "properties": {
+                                    "extent": {
+                                        "type": "null"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "marks": {
             "type": "object",
@@ -210,7 +235,7 @@
                                 "dimensions": []
                             }
                         },
-                        "custom": {},
+                        "custom": {"typeofFunction": true},
                         "config": {
                             "type": "object",
                             "properties": {
@@ -312,7 +337,46 @@
                         }
                     },
                     "required": ["mode"],
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "allOf": [
+                        {
+                            "if": {
+                                "properties": {
+                                    "mode": {
+                                        "enum": ["custom"]
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": ["custom"]
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "mode": {
+                                        "enum": [
+                                            "radar",
+                                            "circle",
+                                            "heatmap",
+                                            "contour"
+                                        ]
+                                    }
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "aggregate": {
+                                        "properties": {
+                                            "dimensions": {
+                                                "maxItems": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 },
                 "hover": {
                     "type": "object",
@@ -332,7 +396,7 @@
                                 "fields": {
                                     "$ref": "#/definitions/nonEmptyStringArray"
                                 },
-                                "custom": {"instanceof": "Function"},
+                                "custom": {"typeofFunction": true},
                                 "orientation": {
                                     "enum": ["vertical", "horizontal"],
                                     "default": "vertical"
@@ -352,7 +416,38 @@
                                 }
                             },
                             "required": ["mode"],
-                            "additionalProperties": false
+                            "additionalProperties": false,
+                            "allOf": [
+                                {
+                                    "if": {
+                                        "properties": {
+                                            "mode": {
+                                                "enum": ["tabular"]
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "required": ["fields"]
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "properties": {
+                                            "mode": {
+                                                "enum": ["custom"]
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "config": {
+                                                "required": ["bboxW", "bboxH"]
+                                            }
+                                        },
+                                        "required": ["custom", "config"]
+                                    }
+                                }
+                            ]
                         },
                         "tooltip": {
                             "type": "object",
@@ -379,7 +474,35 @@
                 }
             },
             "required": ["cluster"],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "cluster": {
+                                "properties": {
+                                    "mode": {
+                                        "enum": ["custom"]
+                                    }
+                                }
+                            },
+                            "hover": {
+                                "anyOf": [
+                                    {"required": ["rankList"]},
+                                    {"required": ["boundary"]}
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "hover": {
+                                "required": ["selector"]
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "config": {
             "type": "object",
@@ -435,5 +558,34 @@
         }
     },
     "required": ["data", "layout", "marks"],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "config": {
+                        "properties": {
+                            "axis": {
+                                "enum": [true]
+                            }
+                        }
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "layout": {
+                        "properties": {
+                            "x": {
+                                "required": ["extent"]
+                            },
+                            "y": {
+                                "required": ["extent"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
 }

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -559,6 +559,26 @@
                     }
                 }
             }
+        },
+        {
+            "if": {
+                "properties": {
+                    "config": {
+                        "properties": {
+                            "map": {
+                                "enum": [true]
+                            }
+                        }
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "layout": {
+                        "required": ["geo"]
+                    }
+                }
+            }
         }
     ]
 }

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -1,0 +1,439 @@
+{
+    "type": "object",
+    "definitions": {
+        "nonEmptyString": {
+            "type": "string",
+            "minLength": 1
+        },
+        "nonEmptyStringArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/nonEmptyString"
+            }
+        },
+        "twoNumberArray": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
+        },
+        "aggregationFunctions": {
+            "enum": ["count", "sum", "avg", "min", "max", "sqrsum"]
+        }
+    },
+    "properties": {
+        "data": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "$ref": "#/definitions/nonEmptyString"
+                },
+                "db": {
+                    "$ref": "#/definitions/nonEmptyString"
+                },
+                "columnNames": {
+                    "default": []
+                }
+            },
+            "required": ["query", "db"],
+            "additionalProperties": false
+        },
+        "layout": {
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "object",
+                    "properties": {
+                        "field": {
+                            "$ref": "#/definitions/nonEmptyString"
+                        },
+                        "extent": {
+                            "$ref": "#/definitions/twoNumberArray"
+                        }
+                    },
+                    "required": ["field"],
+                    "additionalProperties": false
+                },
+                "y": {
+                    "type": "object",
+                    "properties": {
+                        "field": {
+                            "$ref": "#/definitions/nonEmptyString"
+                        },
+                        "extent": {
+                            "$ref": "#/definitions/twoNumberArray"
+                        }
+                    },
+                    "required": ["field"],
+                    "additionalProperties": false
+                },
+                "z": {
+                    "type": "object",
+                    "properties": {
+                        "field": {
+                            "$ref": "#/definitions/nonEmptyString"
+                        },
+                        "order": {
+                            "enum": ["asc", "desc"]
+                        }
+                    },
+                    "required": ["field", "order"],
+                    "additionalProperties": false
+                },
+                "overlap": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "geo": {
+                    "type": "object",
+                    "properties": {
+                        "center": {
+                            "type": "array",
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "items": [
+                                {
+                                    "type": "number",
+                                    "minimum": -90,
+                                    "maximum": 90
+                                },
+                                {
+                                    "type": "number",
+                                    "minimum": -180,
+                                    "maximum": 180
+                                }
+                            ]
+                        },
+                        "level": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 19
+                        }
+                    },
+                    "required": ["center", "level"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["x", "y", "z"],
+            "additionalProperties": false
+        },
+        "marks": {
+            "type": "object",
+            "properties": {
+                "cluster": {
+                    "type": "object",
+                    "properties": {
+                        "mode": {
+                            "enum": [
+                                "custom",
+                                "circle",
+                                "contour",
+                                "heatmap",
+                                "radar",
+                                "pie"
+                            ]
+                        },
+                        "aggregate": {
+                            "type": "object",
+                            "properties": {
+                                "measures": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "field": {
+                                                        "$ref": "#/definitions/nonEmptyString"
+                                                    },
+                                                    "function": {
+                                                        "$ref": "#/definitions/aggregationFunctions"
+                                                    },
+                                                    "extent": {
+                                                        "$ref": "#/definitions/twoNumberArray"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "field",
+                                                    "function"
+                                                ],
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "fields": {
+                                                    "$ref": "#/definitions/nonEmptyStringArray"
+                                                },
+                                                "function": {
+                                                    "$ref": "#/definitions/aggregationFunctions"
+                                                },
+                                                "extent": {
+                                                    "$ref": "#/definitions/twoNumberArray"
+                                                }
+                                            },
+                                            "required": ["fields", "function"],
+                                            "additionalProperties": false
+                                        }
+                                    ],
+                                    "default": []
+                                },
+                                "dimensions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "field": {
+                                                "$ref": "#/definitions/nonEmptyString"
+                                            },
+                                            "domain": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": ["field", "domain"],
+                                        "additionalProperties": false
+                                    },
+                                    "default": []
+                                }
+                            },
+                            "additionalProperties": false,
+                            "default": {
+                                "measures": [],
+                                "dimensions": []
+                            }
+                        },
+                        "custom": {},
+                        "config": {
+                            "type": "object",
+                            "properties": {
+                                "bboxW": {
+                                    "type": "number"
+                                },
+                                "bboxH": {
+                                    "type": "number"
+                                },
+                                "circleMinSize": {
+                                    "type": "number",
+                                    "minimum": 30,
+                                    "maximum": 100,
+                                    "default": 30
+                                },
+                                "circleMaxSize": {
+                                    "type": "number",
+                                    "minimum": 30,
+                                    "maximum": 100,
+                                    "default": 70
+                                },
+                                "contourBandwidth": {
+                                    "type": "number",
+                                    "default": 30
+                                },
+                                "contourRadius": {
+                                    "type": "number",
+                                    "default": 120
+                                },
+                                "contourColorScheme": {
+                                    "type": "string",
+                                    "default": "interpolateViridis"
+                                },
+                                "contourOpacity": {
+                                    "type": "number",
+                                    "minimum": 0.2,
+                                    "maximum": 1,
+                                    "default": 1
+                                },
+                                "heatmapRadius": {
+                                    "type": "number",
+                                    "minimum": 30,
+                                    "maximum": 120,
+                                    "default": 80
+                                },
+                                "heatmapOpacity": {
+                                    "type": "number",
+                                    "minimum": 0.2,
+                                    "maximum": 1,
+                                    "default": 1
+                                },
+                                "radarRadius": {
+                                    "type": "number",
+                                    "minimum": 30,
+                                    "maximum": 120,
+                                    "default": 80
+                                },
+                                "radarTicks": {
+                                    "type": "number",
+                                    "minimum": 2,
+                                    "maximum": 10,
+                                    "default": 5
+                                },
+                                "pieInnerRadius": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 40,
+                                    "default": 1
+                                },
+                                "pieOuterRadius": {
+                                    "type": "number",
+                                    "minimum": 20,
+                                    "maximum": 120,
+                                    "default": 80
+                                },
+                                "pieCornerRadius": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 15,
+                                    "default": 5
+                                },
+                                "padAngle": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 0.5,
+                                    "default": 0.05
+                                },
+                                "numberFormat": {
+                                    "type": "string",
+                                    "default": ".2~s"
+                                },
+                                "clusterCount": {
+                                    "type": "boolean",
+                                    "default": false
+                                }
+                            },
+                            "default": {},
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": ["mode"],
+                    "additionalProperties": false
+                },
+                "hover": {
+                    "type": "object",
+                    "properties": {
+                        "rankList": {
+                            "type": "object",
+                            "properties": {
+                                "mode": {
+                                    "enum": ["tabular", "custom"]
+                                },
+                                "topk": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 8,
+                                    "default": 1
+                                },
+                                "fields": {
+                                    "$ref": "#/definitions/nonEmptyStringArray"
+                                },
+                                "custom": {"instanceof": "Function"},
+                                "orientation": {
+                                    "enum": ["vertical", "horizontal"],
+                                    "default": "vertical"
+                                },
+                                "config": {
+                                    "type": "object",
+                                    "properties": {
+                                        "bboxW": {
+                                            "type": "number"
+                                        },
+                                        "bboxH": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "default": {},
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": ["mode"],
+                            "additionalProperties": false
+                        },
+                        "tooltip": {
+                            "type": "object",
+                            "properties": {
+                                "columns": {
+                                    "$ref": "#/definitions/nonEmptyStringArray"
+                                },
+                                "aliases": {
+                                    "$ref": "#/definitions/nonEmptyStringArray"
+                                }
+                            },
+                            "required": ["columns"],
+                            "additionalProperties": false
+                        },
+                        "boundary": {
+                            "enum": ["bbox", "convexhull"]
+                        },
+                        "selector": {
+                            "$ref": "#/definitions/nonEmptyString"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "default": {}
+                }
+            },
+            "required": ["cluster"],
+            "additionalProperties": false
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "axis": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "xAxisTitle": {
+                    "$ref": "#/definitions/nonEmptyString"
+                },
+                "yAxisTitle": {
+                    "$ref": "#/definitions/nonEmptyString"
+                },
+                "numLevels": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 10
+                },
+                "topLevelWidth": {
+                    "type": "number",
+                    "minimum": 200,
+                    "maximum": 4000,
+                    "default": 1000
+                },
+                "topLevelHeight": {
+                    "type": "number",
+                    "minimum": 200,
+                    "maximum": 4000,
+                    "default": 1000
+                },
+                "zoomFactor": {
+                    "type": "number",
+                    "minimum": 1.1,
+                    "maximum": 5,
+                    "default": 2
+                },
+                "legendTitle": {
+                    "$ref": "#/definitions/nonEmptyString",
+                    "default": "Legend"
+                },
+                "legendDomain": {
+                    "$ref": "#/definitions/nonEmptyStringArray"
+                },
+                "map": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": false,
+            "default": {}
+        }
+    },
+    "required": ["data", "layout", "marks"],
+    "additionalProperties": false
+}

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -323,10 +323,6 @@
                                     "maximum": 0.5,
                                     "default": 0.05
                                 },
-                                "numberFormat": {
-                                    "type": "string",
-                                    "default": ".2~s"
-                                },
                                 "clusterCount": {
                                     "type": "boolean",
                                     "default": false
@@ -524,6 +520,10 @@
                 "map": {
                     "type": "boolean",
                     "default": false
+                },
+                "numberFormat": {
+                    "type": "string",
+                    "default": "~s"
                 }
             },
             "additionalProperties": false,


### PR DESCRIPTION
Added a JSON schema for SSV apis, so that most manual awkward type/constraint/existence/range checking and default value setting in the compiler can be moved to a standard place where they belong. 

End result: the long SSV compiler function is reduced by 50% in LoC. Now it should be much easier to add new templates. 

After this PR, all documented template APIs have switched to JSON schemas. So fixed #122 and fixed #105. 