### PR TITLE
Kyrix-S dot template

### DIFF
--- a/compiler/examples/template-api-examples/README.md
+++ b/compiler/examples/template-api-examples/README.md
@@ -17,13 +17,13 @@ sudo ./compile.sh SSV_circle.js                                                 
 Replace `circle` in the last line with `contour` or `custom` to see `SSV_circle` or `SSV_custom`. 
 
 ## FIFA video game SSVs
-Files `SSV_radar.js` and `SSV_pie.js` correspond to two different SSVs of players in the video game FIFA20. On the left is a radar-chart-based SSV where clusters of players are represented using radar charts that show aggregated player stats on 8 axes. On the right is a pie-chart-based SSV where each pie represents the age group of a cluster of players. 
+Files `SSV_radar.js`, `SSV_pie.js` and `SSV_dot.js` correspond to three different SSVs of players in the video game FIFA20. In the top left is a radar-chart-based SSV where clusters of players are represented using radar charts that show aggregated player stats on 8 axes. In the top right  is a simple dot-based SSV where each dot is a player, its size maps to the player's defensive rating and its color maps to the age group of the player. In the bottom is a pie-chart-based SSV where each pie represents the age group of a cluster of players. 
 
 <p align="center">
-  <img src="https://media.giphy.com/media/JThqBUcoeCw2rhZB1k/giphy.gif" width="750" />
+  <img src="https://media.giphy.com/media/LdBGX7V5GqbUNU0iVw/giphy.gif" width="750" />
 </p>
 
-To get these two applications running, run the following commands:
+To get these three applications running, run the following commands:
 ```
 wget https://www.dropbox.com/s/sd5vx2rkdsqcwtv/fifa20.csv                            # download data
 sudo ./docker-scripts/load-csv.sh fifa20.csv                                         # load data into the db container (must be run in the root folder)
@@ -32,7 +32,7 @@ cd compiler/examples/template-api-examples                                      
 chmod +x compile.sh                                                                  # make the compile script excutable
 sudo ./compile.sh SSV_radar.js                                                       # compile the application
 ```
-Replace `radar` in the last line with `pie` to see `SSV_pie`. 
+Replace `radar` in the last line with `pie/dot` to see `SSV_pie/SSV_dot`. 
 
 ## Other Template API examples
 WIP - stay tuned. 

--- a/compiler/examples/template-api-examples/SSV_dot.js
+++ b/compiler/examples/template-api-examples/SSV_dot.js
@@ -1,0 +1,78 @@
+// To run this example:
+// download this csv file at: https://www.dropbox.com/s/sd5vx2rkdsqcwtv/fifa20.csv
+// then run (in root folder): ./docker-scripts/load-csv.sh fifa20.csv
+// note that the name of the file has to be fifa20.csv
+
+// libraries
+const Project = require("../../src/index").Project;
+const SSV = require("../../src/template-api/SSV").SSV;
+const renderers = require("./renderers");
+
+// construct a project
+var p = new Project("ssv_dot", "../../../config.txt");
+p.addRenderingParams(renderers.renderingParams);
+
+// set up ssv
+var query = "select * from fifa20;";
+
+var ssv = {
+    data: {
+        db: "fifa20",
+        query: query
+    },
+    layout: {
+        x: {
+            field: "rating",
+            extent: [40, 100]
+        },
+        y: {
+            field: "wage",
+            extent: [600, 0]
+        },
+        z: {
+            field: "power",
+            order: "desc"
+        }
+    },
+    marks: {
+        cluster: {
+            mode: "dot",
+            config: {
+                dotSizeColumn: "defending",
+                dotSizeDomain: [0, 100],
+                dotSizeLegendTitle: "Defensive Rating",
+                dotColorColumn: "agegroup",
+                dotColorDomain: ["U29", "U23", "U20", "Older"],
+                dotColorLegendTitle: "Age Group"
+            }
+        },
+        hover: {
+            tooltip: {
+                columns: [
+                    "name",
+                    "rating",
+                    "wage",
+                    "power",
+                    "defending",
+                    "position"
+                ],
+                aliases: [
+                    "Player Name",
+                    "Overall Rating",
+                    "Wage",
+                    "Power",
+                    "Defense",
+                    "Position"
+                ]
+            }
+        }
+    },
+    config: {
+        topLevelWidth: 1500,
+        topLevelHeight: 1000,
+        axis: true
+    }
+};
+
+p.addSSV(new SSV(ssv));
+p.saveProject();

--- a/compiler/examples/template-api-examples/SSV_pie.js
+++ b/compiler/examples/template-api-examples/SSV_pie.js
@@ -57,6 +57,8 @@ var ssv = {
                 // pieCornerRadius: 5,
                 // pieOuterRadius: 80,
                 // pieInnerRadius: 1
+                pieLegendTitle: "Age Groups of Soccer Players in FIFA 2020",
+                pieLegendDomain: ["Under 20", "Under 23", "Under 29", "Older"]
             }
         },
         hover: {
@@ -72,8 +74,6 @@ var ssv = {
         topLevelWidth: 1500,
         topLevelHeight: 1000,
         axis: true,
-        legendTitle: "Age Groups of Soccer Players in FIFA 2020",
-        legendDomain: ["Under 20", "Under 23", "Under 29", "Older"],
         numberFormat: ".2~s"
     }
 };

--- a/compiler/src/template-api/SSV.js
+++ b/compiler/src/template-api/SSV.js
@@ -192,15 +192,6 @@ function SSV(args_) {
     }
 
     /***************************
-     * setting legend parameters
-     ***************************/
-    // TODO: legend params for different templates
-    this.legendParams = {};
-    this.legendParams.legendTitle = args.config.legendTitle;
-    if ("legendDomain" in args.config)
-        this.legendParams.legendDomain = args.config.legendDomain;
-
-    /***************************
      * setting axis parameters
      ***************************/
     this.axisParams = {};
@@ -1426,8 +1417,8 @@ function getLegendRenderer() {
         var color = d3
             .scaleOrdinal(d3.schemeTableau10)
             .domain(
-                "legendDomain" in params
-                    ? params.legendDomain
+                "pieLegendDomain" in params
+                    ? params.pieLegendDomain
                     : params.aggDomain
             );
         var legendOrdinal = d3
@@ -1439,7 +1430,7 @@ function getLegendRenderer() {
             .shape("rect")
             //.orient("horizontal")
             .shapePadding(10)
-            .title(params.legendTitle)
+            .title(params.pieLegendTitle)
             .labelOffset(15)
             //.titleWidth(200)
             // .labelAlign("start")

--- a/compiler/src/template-api/SSV.js
+++ b/compiler/src/template-api/SSV.js
@@ -228,7 +228,7 @@ function SSV(args_) {
     else if (args.marks.cluster.mode == "pie") this.bboxW = this.bboxH = 290;
     // tuned by hand :)
     else if (args.marks.cluster.mode == "dot")
-        this.bboxW = this.bboxH = this.clusterParams.dotMaxSize * 2;
+        this.bboxW = this.bboxH = this.clusterParams.dotMaxSize * 2.5;
 
     // assign other fields
     this.query = args.data.query.toLowerCase();

--- a/compiler/src/template-api/SSV.js
+++ b/compiler/src/template-api/SSV.js
@@ -228,7 +228,7 @@ function SSV(args_) {
     else if (args.marks.cluster.mode == "pie") this.bboxW = this.bboxH = 290;
     // tuned by hand :)
     else if (args.marks.cluster.mode == "dot")
-        this.bboxW = this.bboxH = this.clusterParams.dotMaxSize * 2.5;
+        this.bboxW = this.bboxH = this.clusterParams.dotMaxSize * 3;
 
     // assign other fields
     this.query = args.data.query.toLowerCase();
@@ -997,42 +997,45 @@ function getLayerRenderer() {
     }
 
     function renderDotBody() {
+        if (!data || data.length == 0) return;
+
         var rpKey = "ssv_" + args.ssvId.substring(0, args.ssvId.indexOf("_"));
         var params = args.renderingParams[rpKey];
         var g = svg.append("g");
         params.processClusterAgg(data, params);
 
         // size scale
-        if (!("dotSizeDomain" in params))
-            params.dotSizeDomain = d3.extent(
-                data.map(d => +d[params.dotSizeColumn])
-            );
-        var dotSizeScale = d3
-            .scaleLinear()
-            .domain(params.dotSizeDomain)
-            .range([0, params.dotMaxSize]);
+        var dotSizeScale = null;
+        if ("dotSizeColumn" in params)
+            dotSizeScale = d3
+                .scaleLinear()
+                .domain(params.dotSizeDomain)
+                .range([0, params.dotMaxSize]);
 
         // color scale
-        if (!("dotColorDomain" in params)) {
-            params.dotColorDomain = [];
-            var arr = data.map(d => d.dotColorColumn).sort();
-            for (var i = 0; i < arr.length; i++)
-                if (i == 0 || arr[i] !== arr[i - 1])
-                    params.dotColorDomain.push(arr[i]);
-        }
-        var dotColorScale = d3.scaleOrdinal(
-            params.dotColorDomain,
-            d3.schemeTableau10
-        );
+        var dotColorScale = null;
+        if ("dotColorColumn" in params)
+            dotColorScale = d3.scaleOrdinal(
+                params.dotColorDomain,
+                d3.schemeTableau10
+            );
 
         g.selectAll(".ssvdot")
             .data(data)
             .join("circle")
-            .attr("r", d => dotSizeScale(+d[params.dotSizeColumn]))
+            .attr("r", d =>
+                "dotSizeColumn" in params
+                    ? dotSizeScale(+d[params.dotSizeColumn])
+                    : params.dotMaxSize
+            )
             .attr("cx", d => +d.cx)
             .attr("cy", d => +d.cy)
             .style("fill-opacity", 0)
-            .attr("stroke", d => dotColorScale(d[params.dotColorColumn]))
+            .attr("stroke", d =>
+                "dotColorColumn" in params
+                    ? dotColorScale(d[params.dotColorColumn])
+                    : "#38c2e0"
+            )
             .style("stroke-width", "2px")
             .classed("kyrix-retainsizezoom", true);
     }
@@ -1444,63 +1447,69 @@ function getLegendRenderer() {
         var rpKey = "ssv_" + args.ssvId.substring(0, args.ssvId.indexOf("_"));
         var params = args.renderingParams[rpKey];
 
-        // size legend
-        if (!("dotSizeDomain" in params))
-            params.dotSizeDomain = d3.extent(
-                data.map(d => +d[params.dotSizeColumn])
-            );
-        var dotSizeScale = d3
-            .scaleLinear()
-            .domain(params.dotSizeDomain)
-            .range([0, params.dotMaxSize]);
-        var legendSize = d3
-            .legendSize()
-            .scale(dotSizeScale)
-            .shape("circle")
-            .shapePadding(25)
-            .labelOffset(20)
-            .title(params.dotSizeLegendTitle)
-            .orient("horizontal");
+        // a <g> for holding the legends
         var legendG = svg
             .append("g")
             .classed("ssv_dot_legend", true)
             .style("opacity", 0.5)
             .attr("transform", "translate(50, 0)");
-        legendG
-            .append("g")
-            .attr("transform", "translate(120, 20)")
-            .call(legendSize);
+
+        // horizontal offset
+        var offset = 0;
+        // size legend
+        if ("dotSizeColumn" in params) {
+            var dotSizeScale = d3
+                .scaleLinear()
+                .domain(params.dotSizeDomain)
+                .range([0, params.dotMaxSize]);
+            var legendSize = d3
+                .legendSize()
+                .scale(dotSizeScale)
+                .shape("circle")
+                .shapePadding(25)
+                .labelOffset(20)
+                .title(
+                    "dotSizeLegendTitle" in params
+                        ? params.dotSizeLegendTitle
+                        : "Point Size"
+                )
+                .orient("horizontal");
+            legendG
+                .append("g")
+                .attr("transform", `translate(${offset}, 20)`)
+                .call(legendSize);
+            offset += 200;
+        }
 
         // color legend
-        if (!("dotColorDomain" in params)) {
-            params.dotColorDomain = [];
-            var arr = data.map(d => d.dotColorColumn).sort();
-            for (var i = 0; i < arr.length; i++)
-                if (i == 0 || arr[i] !== arr[i - 1])
-                    params.dotColorDomain.push(arr[i]);
+        if ("dotColorColumn" in params) {
+            var dotColorScale = d3.scaleOrdinal(
+                params.dotColorDomain,
+                d3.schemeTableau10
+            );
+            var legendColor = d3
+                .legendColor()
+                .shape("rect")
+                .shapePadding(5)
+                .title(
+                    "dotColorLegendTitle" in params
+                        ? params.dotColorLegendTitle
+                        : "Point Color"
+                )
+                .labelOffset(13)
+                .scale(dotColorScale);
+            legendG
+                .append("g")
+                .attr("transform", `translate(${offset}, 20) scale(1)`)
+                .call(legendColor);
         }
-        var dotColorScale = d3.scaleOrdinal(
-            params.dotColorDomain,
-            d3.schemeTableau10
-        );
-        var legendColor = d3
-            .legendColor()
-            .shape("rect")
-            .shapePadding(5)
-            .title(params.dotColorLegendTitle)
-            .labelOffset(13)
-            .scale(dotColorScale);
-        legendG
-            .append("g")
-            .attr("transform", "translate(0, 20) scale(1)")
-            .call(legendColor);
 
         // transparent rectangle to receive hover events
         legendG
             .append("rect")
             .attr("x", 0)
             .attr("y", 0)
-            .attr("width", legendG.node().getBBox().width)
+            .attr("width", legendG.node().getBBox().width + 20)
             .attr("height", legendG.node().getBBox().height)
             .style("opacity", 0)
             .on("mouseover", function() {

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -331,8 +331,14 @@
                                 "pieLegendDomain": {
                                     "$ref": "#/definitions/nonEmptyStringArray"
                                 },
+                                "dotSizeColumn": {
+                                    "$ref": "#/definitions/nonEmptyString"
+                                },
                                 "dotSizeDomain": {
                                     "$ref": "#/definitions/twoNumberArray"
+                                },
+                                "dotSizeLegendTitle": {
+                                    "$ref": "#/definitions/nonEmptyString"
                                 },
                                 "dotMaxSize": {
                                     "type": "integer",
@@ -340,10 +346,7 @@
                                     "maximum": 50,
                                     "default": 15
                                 },
-                                "dotSizeColumn": {
-                                    "$ref": "#/definitions/nonEmptyString"
-                                },
-                                "dotSizeLegendTitle": {
+                                "dotColorColumn": {
                                     "$ref": "#/definitions/nonEmptyString"
                                 },
                                 "dotColorDomain": {
@@ -353,9 +356,6 @@
                                     },
                                     "minItems": 1,
                                     "maxItems": 8
-                                },
-                                "dotColorColumn": {
-                                    "$ref": "#/definitions/nonEmptyString"
                                 },
                                 "dotColorLegendTitle": {
                                     "$ref": "#/definitions/nonEmptyString"

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -324,6 +324,13 @@
                                     "maximum": 0.5,
                                     "default": 0.05
                                 },
+                                "pieLegendTitle": {
+                                    "$ref": "#/definitions/nonEmptyString",
+                                    "default": "Legend"
+                                },
+                                "pieLegendDomain": {
+                                    "$ref": "#/definitions/nonEmptyStringArray"
+                                },
                                 "dotSizeDomain": {
                                     "$ref": "#/definitions/twoNumberArray"
                                 },
@@ -571,13 +578,6 @@
                     "minimum": 1.1,
                     "maximum": 5,
                     "default": 2
-                },
-                "legendTitle": {
-                    "$ref": "#/definitions/nonEmptyString",
-                    "default": "Legend"
-                },
-                "legendDomain": {
-                    "$ref": "#/definitions/nonEmptyStringArray"
                 },
                 "map": {
                     "type": "boolean",

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -159,7 +159,8 @@
                                 "contour",
                                 "heatmap",
                                 "radar",
-                                "pie"
+                                "pie",
+                                "dot"
                             ]
                         },
                         "aggregate": {
@@ -323,6 +324,29 @@
                                     "maximum": 0.5,
                                     "default": 0.05
                                 },
+                                "dotSizeDomain": {
+                                    "$ref": "#/definitions/twoNumberArray"
+                                },
+                                "dotMaxSize": {
+                                    "type": "number",
+                                    "minimum": 5,
+                                    "maximum": 50,
+                                    "default": 15
+                                },
+                                "dotSizeColumn": {
+                                    "$ref": "#/definitions/nonEmptyString"
+                                },
+                                "dotColorDomain": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 8
+                                },
+                                "dotColorColumn": {
+                                    "$ref": "#/definitions/nonEmptyString"
+                                },
                                 "clusterCount": {
                                     "type": "boolean",
                                     "default": false
@@ -368,6 +392,36 @@
                                                 "maxItems": 0
                                             }
                                         }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "mode": {
+                                        "enum": ["dot"]
+                                    }
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "aggregate": {
+                                        "properties": {
+                                            "measures": {
+                                                "type": "array",
+                                                "maxItems": 0
+                                            },
+                                            "dimensions": {
+                                                "maxItems": 0
+                                            }
+                                        }
+                                    },
+                                    "config": {
+                                        "required": [
+                                            "dotSizeColumn",
+                                            "dotColorColumn"
+                                        ]
                                     }
                                 }
                             }

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -241,29 +241,29 @@
                             "type": "object",
                             "properties": {
                                 "bboxW": {
-                                    "type": "number"
+                                    "type": "integer"
                                 },
                                 "bboxH": {
-                                    "type": "number"
+                                    "type": "integer"
                                 },
                                 "circleMinSize": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 30,
                                     "maximum": 100,
                                     "default": 30
                                 },
                                 "circleMaxSize": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 30,
                                     "maximum": 100,
                                     "default": 70
                                 },
                                 "contourBandwidth": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "default": 30
                                 },
                                 "contourRadius": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "default": 120
                                 },
                                 "contourColorScheme": {
@@ -277,7 +277,7 @@
                                     "default": 1
                                 },
                                 "heatmapRadius": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 30,
                                     "maximum": 120,
                                     "default": 80
@@ -289,31 +289,31 @@
                                     "default": 1
                                 },
                                 "radarRadius": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 30,
                                     "maximum": 120,
                                     "default": 80
                                 },
                                 "radarTicks": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 2,
                                     "maximum": 10,
                                     "default": 5
                                 },
                                 "pieInnerRadius": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 0,
                                     "maximum": 40,
                                     "default": 1
                                 },
                                 "pieOuterRadius": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 20,
                                     "maximum": 120,
                                     "default": 80
                                 },
                                 "pieCornerRadius": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 0,
                                     "maximum": 15,
                                     "default": 5
@@ -335,7 +335,7 @@
                                     "$ref": "#/definitions/twoNumberArray"
                                 },
                                 "dotMaxSize": {
-                                    "type": "number",
+                                    "type": "integer",
                                     "minimum": 5,
                                     "maximum": 50,
                                     "default": 15
@@ -344,8 +344,7 @@
                                     "$ref": "#/definitions/nonEmptyString"
                                 },
                                 "dotSizeLegendTitle": {
-                                    "$ref": "#/definitions/nonEmptyString",
-                                    "default": "Point Size"
+                                    "$ref": "#/definitions/nonEmptyString"
                                 },
                                 "dotColorDomain": {
                                     "type": "array",
@@ -359,8 +358,7 @@
                                     "$ref": "#/definitions/nonEmptyString"
                                 },
                                 "dotColorLegendTitle": {
-                                    "$ref": "#/definitions/nonEmptyString",
-                                    "default": "Point Color"
+                                    "$ref": "#/definitions/nonEmptyString"
                                 },
                                 "clusterCount": {
                                     "type": "boolean",
@@ -368,7 +366,59 @@
                                 }
                             },
                             "default": {},
-                            "additionalProperties": false
+                            "additionalProperties": false,
+                            "allOf": [
+                                {
+                                    "if": {
+                                        "anyOf": [
+                                            {
+                                                "required": ["dotSizeDomain"]
+                                            },
+                                            {
+                                                "required": [
+                                                    "dotSizeLegendTitle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "required": ["dotSizeColumn"]
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "required": ["dotSizeColumn"]
+                                    },
+                                    "then": {
+                                        "required": ["dotSizeDomain"]
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "anyOf": [
+                                            {
+                                                "required": ["dotColorDomain"]
+                                            },
+                                            {
+                                                "required": [
+                                                    "dotColorLegendTitle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "required": ["dotColorColumn"]
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "required": ["dotColorColumn"]
+                                    },
+                                    "then": {
+                                        "required": ["dotColorDomain"]
+                                    }
+                                }
+                            ]
                         }
                     },
                     "required": ["mode"],
@@ -431,12 +481,6 @@
                                                 "maxItems": 0
                                             }
                                         }
-                                    },
-                                    "config": {
-                                        "required": [
-                                            "dotSizeColumn",
-                                            "dotColorColumn"
-                                        ]
                                     }
                                 }
                             }

--- a/compiler/src/template-api/json-schema/SSV.json
+++ b/compiler/src/template-api/json-schema/SSV.json
@@ -336,6 +336,10 @@
                                 "dotSizeColumn": {
                                     "$ref": "#/definitions/nonEmptyString"
                                 },
+                                "dotSizeLegendTitle": {
+                                    "$ref": "#/definitions/nonEmptyString",
+                                    "default": "Point Size"
+                                },
                                 "dotColorDomain": {
                                     "type": "array",
                                     "items": {
@@ -346,6 +350,10 @@
                                 },
                                 "dotColorColumn": {
                                     "$ref": "#/definitions/nonEmptyString"
+                                },
+                                "dotColorLegendTitle": {
+                                    "$ref": "#/definitions/nonEmptyString",
+                                    "default": "Point Color"
                                 },
                                 "clusterCount": {
                                     "type": "boolean",


### PR DESCRIPTION
A new Kyrix-S template that will make it easy to author the simplest point-based scatterplots. Options to map point size/color to data fields. Original motivation was to templatize all renderers from the MIT Kyrix-J demo. 

Relevant spec:
```Javascript
...
    marks: {
        cluster: {
            mode: "dot",
            config: {
                dotSizeColumn: "defending",
                dotSizeDomain: [0, 100],
                dotSizeLegendTitle: "Defensive Rating",
                dotColorColumn: "agegroup",
                dotColorDomain: ["U29", "U23", "U20", "Older"],
                dotColorLegendTitle: "Age Group"
            }
        },
...
```

which results in:
![alt text](https://media.giphy.com/media/jaEDzSLT9XCfE5K1vm/giphy.gif)

